### PR TITLE
Add Windows support (socket types, OpenSSL linking, IPv6 fallback)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          choco install cmake pkgconfiglite strawberryperl -y
+          choco install pkgconfiglite strawberryperl -y
 
           # Find and configure OpenSSL
           $opensslPaths = @(
@@ -170,6 +170,7 @@ jobs:
               if ($libDir) {
                 echo "OPENSSL_DIR=$path" >> $env:GITHUB_ENV
                 echo "OPENSSL_ROOT_DIR=$path" >> $env:GITHUB_ENV
+                echo "OPENSSL64DIR=$path" >> $env:GITHUB_ENV
                 echo "OPENSSL_LIB_DIR=$libDir" >> $env:GITHUB_ENV
                 echo "OPENSSL_INCLUDE_DIR=$path\include" >> $env:GITHUB_ENV
                 Write-Host "OpenSSL configured at $path (libs in $libDir)"
@@ -204,6 +205,12 @@ jobs:
               break
             }
           }
+
+      - name: Build picoquic with upstream Windows flow
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          .\scripts\build_picoquic_windows.ps1
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,11 @@ jobs:
             (cd "${dist_dir}" && shasum -a 256 "slipstream-client${bin_suffix}" "slipstream-server${bin_suffix}" > "${base_name}.sha256")
           fi
 
+      - name: Verify Windows artifact dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/verify_windows_artifact_deps.ps1 -DistDir dist
+
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,31 +154,6 @@ jobs:
         run: |
           choco install pkgconfiglite strawberryperl -y
 
-          # Find and configure OpenSSL
-          $opensslPaths = @(
-            "C:\Program Files\OpenSSL",
-            "C:\Program Files\OpenSSL-Win64",
-            "C:\OpenSSL-Win64",
-            "C:\OpenSSL"
-          )
-
-          foreach ($path in $opensslPaths) {
-            if (Test-Path $path) {
-              $libDir = Get-ChildItem -Path "$path\lib" -Filter "libcrypto*.lib" -Recurse -ErrorAction SilentlyContinue |
-                        Select-Object -First 1 | ForEach-Object { $_.DirectoryName }
-
-              if ($libDir) {
-                echo "OPENSSL_DIR=$path" >> $env:GITHUB_ENV
-                echo "OPENSSL_ROOT_DIR=$path" >> $env:GITHUB_ENV
-                echo "OPENSSL64DIR=$path" >> $env:GITHUB_ENV
-                echo "OPENSSL_LIB_DIR=$libDir" >> $env:GITHUB_ENV
-                echo "OPENSSL_INCLUDE_DIR=$path\include" >> $env:GITHUB_ENV
-                Write-Host "OpenSSL configured at $path (libs in $libDir)"
-                break
-              }
-            }
-          }
-
           # Setup Perl for OpenSSL vendored build
           $perlPaths = @(
             "C:\Strawberry\perl\bin",
@@ -216,6 +191,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Test slipstream-ffi (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cargo test -p slipstream-ffi --target ${{ matrix.target }}
 
       - name: Build slipstream-client
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,20 +213,12 @@ jobs:
       - name: Build slipstream-client
         shell: bash
         run: |
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cargo build -p slipstream-client --release --target ${{ matrix.target }} --features openssl-vendored
-          else
-            cargo build -p slipstream-client --release --target ${{ matrix.target }}
-          fi
+          cargo build -p slipstream-client --release --target ${{ matrix.target }}
 
       - name: Build slipstream-server
         shell: bash
         run: |
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cargo build -p slipstream-server --release --target ${{ matrix.target }} --features openssl-vendored
-          else
-            cargo build -p slipstream-server --release --target ${{ matrix.target }}
-          fi
+          cargo build -p slipstream-server --release --target ${{ matrix.target }}
 
       - name: Package binaries
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,10 @@ jobs:
             runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: slipstream-linux-x86_64
+          - name: windows-x86_64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact_name: slipstream-windows-x86_64
     steps:
       - name: Check out slipstream-rust
         uses: actions/checkout@v4
@@ -144,6 +148,32 @@ jobs:
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
           echo "PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig" >> "$GITHUB_ENV"
 
+      - name: Install build dependencies (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          VCPKG_ROOT: C:\vcpkg
+          VCPKG_INSTALLATION_ROOT: C:\vcpkg
+          VCPKG_DEFAULT_TRIPLET: x64-windows
+          VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (!(Test-Path "$vcpkgRoot\vcpkg.exe")) {
+            Write-Error "vcpkg.exe not found at $vcpkgRoot. Expected GitHub runner preinstall."
+          }
+          & "$vcpkgRoot\vcpkg.exe" install openssl:x64-windows
+          $installed = Join-Path $vcpkgRoot "installed\x64-windows"
+          "OPENSSL_ROOT_DIR=$installed" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_INCLUDE_DIR=$installed\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_LIB_DIR=$installed\lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_DIR=$installed" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $gitBin = "C:\Program Files\Git\bin"
+          $gitUsrBin = "C:\Program Files\Git\usr\bin"
+          if (!(Test-Path $gitBin)) {
+            Write-Error "Git Bash not found at $gitBin."
+          }
+          "PATH=$gitBin;$gitUsrBin;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -162,13 +192,17 @@ jobs:
           dist_dir="dist"
           base_name="${{ matrix.artifact_name }}"
           bin_dir="target/${{ matrix.target }}/release"
+          bin_suffix=""
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            bin_suffix=".exe"
+          fi
           mkdir -p "${dist_dir}"
-          cp "${bin_dir}/slipstream-client" "${dist_dir}/"
-          cp "${bin_dir}/slipstream-server" "${dist_dir}/"
+          cp "${bin_dir}/slipstream-client${bin_suffix}" "${dist_dir}/"
+          cp "${bin_dir}/slipstream-server${bin_suffix}" "${dist_dir}/"
           if command -v sha256sum >/dev/null 2>&1; then
-            (cd "${dist_dir}" && sha256sum slipstream-client slipstream-server > "${base_name}.sha256")
+            (cd "${dist_dir}" && sha256sum "slipstream-client${bin_suffix}" "slipstream-server${bin_suffix}" > "${base_name}.sha256")
           else
-            (cd "${dist_dir}" && shasum -a 256 slipstream-client slipstream-server > "${base_name}.sha256")
+            (cd "${dist_dir}" && shasum -a 256 "slipstream-client${bin_suffix}" "slipstream-server${bin_suffix}" > "${base_name}.sha256")
           fi
 
       - name: Upload binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,28 +151,59 @@ jobs:
       - name: Install build dependencies (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        env:
-          VCPKG_ROOT: C:\vcpkg
-          VCPKG_INSTALLATION_ROOT: C:\vcpkg
-          VCPKG_DEFAULT_TRIPLET: x64-windows
-          VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
         run: |
-          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
-          if (!(Test-Path "$vcpkgRoot\vcpkg.exe")) {
-            Write-Error "vcpkg.exe not found at $vcpkgRoot. Expected GitHub runner preinstall."
+          choco install cmake pkgconfiglite strawberryperl -y
+
+          # Find and configure OpenSSL
+          $opensslPaths = @(
+            "C:\Program Files\OpenSSL",
+            "C:\Program Files\OpenSSL-Win64",
+            "C:\OpenSSL-Win64",
+            "C:\OpenSSL"
+          )
+
+          foreach ($path in $opensslPaths) {
+            if (Test-Path $path) {
+              $libDir = Get-ChildItem -Path "$path\lib" -Filter "libcrypto*.lib" -Recurse -ErrorAction SilentlyContinue |
+                        Select-Object -First 1 | ForEach-Object { $_.DirectoryName }
+
+              if ($libDir) {
+                echo "OPENSSL_DIR=$path" >> $env:GITHUB_ENV
+                echo "OPENSSL_ROOT_DIR=$path" >> $env:GITHUB_ENV
+                echo "OPENSSL_LIB_DIR=$libDir" >> $env:GITHUB_ENV
+                echo "OPENSSL_INCLUDE_DIR=$path\include" >> $env:GITHUB_ENV
+                Write-Host "OpenSSL configured at $path (libs in $libDir)"
+                break
+              }
+            }
           }
-          & "$vcpkgRoot\vcpkg.exe" install openssl:x64-windows
-          $installed = Join-Path $vcpkgRoot "installed\x64-windows"
-          "OPENSSL_ROOT_DIR=$installed" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_INCLUDE_DIR=$installed\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_LIB_DIR=$installed\lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_DIR=$installed" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          $gitBin = "C:\Program Files\Git\bin"
-          $gitUsrBin = "C:\Program Files\Git\usr\bin"
-          if (!(Test-Path $gitBin)) {
-            Write-Error "Git Bash not found at $gitBin."
+
+          # Setup Perl for OpenSSL vendored build
+          $perlPaths = @(
+            "C:\Strawberry\perl\bin",
+            "C:\Program Files\Strawberry\perl\bin",
+            "${env:ProgramFiles}\Strawberry\perl\bin"
+          )
+
+          foreach ($path in $perlPaths) {
+            $exe = Join-Path $path "perl.exe"
+            if (Test-Path $exe) {
+              $env:Path = "$path;$env:Path"
+              echo "PATH=$path`;$env:Path" >> $env:GITHUB_ENV
+              echo "PERL=$exe" >> $env:GITHUB_ENV
+              Write-Host "Found Strawberry Perl at $path"
+
+              # Install Locale::Maketext::Simple if needed
+              $moduleCheck = & $exe -e "use Locale::Maketext::Simple; print 'OK'" 2>&1
+              if ($LASTEXITCODE -ne 0) {
+                $cpanmExe = Join-Path $path "cpanm.bat"
+                if (Test-Path $cpanmExe) {
+                  & $cpanmExe --notest Locale::Maketext::Simple 2>&1 | Out-String | Write-Host
+                }
+              }
+              break
+            }
           }
-          "PATH=$gitBin;$gitUsrBin;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -180,10 +211,22 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build slipstream-client
-        run: cargo build -p slipstream-client --release --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cargo build -p slipstream-client --release --target ${{ matrix.target }} --features openssl-vendored
+          else
+            cargo build -p slipstream-client --release --target ${{ matrix.target }}
+          fi
 
       - name: Build slipstream-server
-        run: cargo build -p slipstream-server --release --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cargo build -p slipstream-server --release --target ${{ matrix.target }} --features openssl-vendored
+          else
+            cargo build -p slipstream-server --release --target ${{ matrix.target }}
+          fi
 
       - name: Package binaries
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,39 +148,6 @@ jobs:
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
           echo "PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig" >> "$GITHUB_ENV"
 
-      - name: Install build dependencies (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          choco install pkgconfiglite strawberryperl -y
-
-          # Setup Perl for OpenSSL vendored build
-          $perlPaths = @(
-            "C:\Strawberry\perl\bin",
-            "C:\Program Files\Strawberry\perl\bin",
-            "${env:ProgramFiles}\Strawberry\perl\bin"
-          )
-
-          foreach ($path in $perlPaths) {
-            $exe = Join-Path $path "perl.exe"
-            if (Test-Path $exe) {
-              $env:Path = "$path;$env:Path"
-              echo "PATH=$path`;$env:Path" >> $env:GITHUB_ENV
-              echo "PERL=$exe" >> $env:GITHUB_ENV
-              Write-Host "Found Strawberry Perl at $path"
-
-              # Install Locale::Maketext::Simple if needed
-              $moduleCheck = & $exe -e "use Locale::Maketext::Simple; print 'OK'" 2>&1
-              if ($LASTEXITCODE -ne 0) {
-                $cpanmExe = Join-Path $path "cpanm.bat"
-                if (Test-Path $cpanmExe) {
-                  & $cpanmExe --notest Locale::Maketext::Simple 2>&1 | Out-String | Write-Host
-                }
-              }
-              break
-            }
-          }
-
       - name: Build picoquic with upstream Windows flow
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.interop/
 /tools/vector_gen/build/
 /.picoquic-build/
+/vendor/picotls/
 /vendor/picoquic/build/
 /.worktrees/
 .idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,9 +453,11 @@ dependencies = [
 name = "slipstream-ffi"
 version = "0.1.0"
 dependencies = [
+ "cc",
  "libc",
  "openssl-sys",
  "slipstream-core",
+ "winapi",
 ]
 
 [[package]]
@@ -663,6 +665,28 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ Initialize the picoquic submodule:
 git submodule update --init --recursive
 ```
 
-`cargo build` will auto-build picoquic via `./scripts/build_picoquic.sh` when
-libs are missing (outputs to `.picoquic-build/`). Set `PICOQUIC_AUTO_BUILD=0`
-to disable or see `docs/build.md` for manual control.
+On non-Windows hosts, `cargo build` will auto-build picoquic via
+`./scripts/build_picoquic.sh` when libs are missing (outputs to
+`.picoquic-build/`). Windows targets are only supported from a Windows host:
+run `pwsh -File ./scripts/build_picoquic_windows.ps1` once, then build with
+Cargo. See `docs/build.md` for details.
 
 Build the Rust binaries:
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ git submodule update --init --recursive
 
 On non-Windows hosts, `cargo build` will auto-build picoquic via
 `./scripts/build_picoquic.sh` when libs are missing (outputs to
-`.picoquic-build/`). Windows targets are only supported from a Windows host:
-run `pwsh -File ./scripts/build_picoquic_windows.ps1` once, then build with
-Cargo. See `docs/build.md` for details.
+`.picoquic-build/`). The Windows `x86_64-pc-windows-msvc` target is only
+supported from a Windows host: run `pwsh -File ./scripts/build_picoquic_windows.ps1`
+once, then build with Cargo. See `docs/build.md` for details.
 
 Build the Rust binaries:
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ git submodule update --init --recursive
 
 On non-Windows hosts, `cargo build` will auto-build picoquic via
 `./scripts/build_picoquic.sh` when libs are missing (outputs to
-`.picoquic-build/`). The Windows `x86_64-pc-windows-msvc` target is only
-supported from a Windows host: run `pwsh -File ./scripts/build_picoquic_windows.ps1`
-once, then build with Cargo. See `docs/build.md` for details.
+`.picoquic-build/`). For the Windows `x86_64-pc-windows-msvc` CI flow, run
+`pwsh -File ./scripts/build_picoquic_windows.ps1` once, then build with Cargo.
+See `docs/build.md` for details.
 
 Build the Rust binaries:
 

--- a/crates/slipstream-client/src/dns/path.rs
+++ b/crates/slipstream-client/src/dns/path.rs
@@ -51,7 +51,7 @@ pub(crate) fn add_paths(
         return Ok(());
     }
 
-    let mut local_storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+    let mut local_storage: slipstream_ffi::SockaddrStorage = unsafe { std::mem::zeroed() };
     let ret = unsafe { picoquic_get_path_addr(cnx, 0, 1, &mut local_storage) };
     if ret != 0 {
         return Ok(());

--- a/crates/slipstream-client/src/dns/poll.rs
+++ b/crates/slipstream-client/src/dns/poll.rs
@@ -35,7 +35,7 @@ pub(crate) async fn send_poll_queries(
     cnx: *mut picoquic_cnx_t,
     udp: &TokioUdpSocket,
     config: &ClientConfig<'_>,
-    local_addr_storage: &mut libc::sockaddr_storage,
+    local_addr_storage: &mut slipstream_ffi::SockaddrStorage,
     dns_id: &mut u16,
     resolver: &mut ResolverState,
     remaining: &mut usize,
@@ -54,8 +54,8 @@ pub(crate) async fn send_poll_queries(
         }
 
         let mut send_length: libc::size_t = 0;
-        let mut addr_to: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-        let mut addr_from: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+        let mut addr_to: slipstream_ffi::SockaddrStorage = unsafe { std::mem::zeroed() };
+        let mut addr_from: slipstream_ffi::SockaddrStorage = unsafe { std::mem::zeroed() };
         let mut if_index: libc::c_int = 0;
         let ret = unsafe {
             picoquic_prepare_packet_ex(

--- a/crates/slipstream-client/src/dns/resolver.rs
+++ b/crates/slipstream-client/src/dns/resolver.rs
@@ -10,8 +10,8 @@ use super::debug::DebugMetrics;
 
 pub(crate) struct ResolverState {
     pub(crate) addr: SocketAddr,
-    pub(crate) storage: libc::sockaddr_storage,
-    pub(crate) local_addr_storage: Option<libc::sockaddr_storage>,
+    pub(crate) storage: slipstream_ffi::SockaddrStorage,
+    pub(crate) local_addr_storage: Option<slipstream_ffi::SockaddrStorage>,
     pub(crate) mode: ResolverMode,
     pub(crate) added: bool,
     pub(crate) path_id: libc::c_int,
@@ -93,7 +93,7 @@ pub(crate) fn reset_resolver_path(resolver: &mut ResolverState) {
 }
 
 pub(crate) fn sockaddr_storage_to_socket_addr(
-    storage: &libc::sockaddr_storage,
+    storage: &slipstream_ffi::SockaddrStorage,
 ) -> Result<SocketAddr, ClientError> {
     slipstream_ffi::sockaddr_storage_to_socket_addr(storage).map_err(ClientError::new)
 }

--- a/crates/slipstream-client/src/dns/response.rs
+++ b/crates/slipstream-client/src/dns/response.rs
@@ -14,7 +14,7 @@ const MAX_POLL_BURST: usize = PICOQUIC_PACKET_LOOP_RECV_MAX;
 
 pub(crate) struct DnsResponseContext<'a> {
     pub(crate) quic: *mut picoquic_quic_t,
-    pub(crate) local_addr_storage: &'a libc::sockaddr_storage,
+    pub(crate) local_addr_storage: &'a slipstream_ffi::SockaddrStorage,
     pub(crate) resolvers: &'a mut [ResolverState],
 }
 

--- a/crates/slipstream-client/src/runtime.rs
+++ b/crates/slipstream-client/src/runtime.rs
@@ -355,8 +355,8 @@ pub async fn run_client(config: &ClientConfig<'_>) -> Result<i32, ClientError> {
             for _ in 0..packet_loop_send_max {
                 let current_time = unsafe { picoquic_current_time() };
                 let mut send_length: libc::size_t = 0;
-                let mut addr_to: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-                let mut addr_from: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+                let mut addr_to: slipstream_ffi::SockaddrStorage = unsafe { std::mem::zeroed() };
+                let mut addr_from: slipstream_ffi::SockaddrStorage = unsafe { std::mem::zeroed() };
                 let mut if_index: libc::c_int = 0;
                 let mut log_cid = picoquic_connection_id_t {
                     id: [0; PICOQUIC_CONNECTION_ID_MAX_SIZE],

--- a/crates/slipstream-client/src/runtime/path.rs
+++ b/crates/slipstream-client/src/runtime/path.rs
@@ -86,7 +86,7 @@ pub(crate) fn drain_path_events(
 }
 
 fn path_peer_addr(cnx: *mut picoquic_cnx_t, unique_path_id: u64) -> Option<SocketAddr> {
-    let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+    let mut storage: slipstream_ffi::SockaddrStorage = unsafe { std::mem::zeroed() };
     let ret = unsafe { picoquic_get_path_addr(cnx, unique_path_id, 2, &mut storage) };
     if ret != 0 {
         return None;

--- a/crates/slipstream-client/src/runtime/setup.rs
+++ b/crates/slipstream-client/src/runtime/setup.rs
@@ -25,8 +25,12 @@ pub(crate) async fn bind_udp_socket() -> Result<TokioUdpSocket, ClientError> {
     let bind_addr_v6 = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0));
     match bind_udp_socket_addr(bind_addr_v6, "UDP socket") {
         Ok(socket) => Ok(socket),
-        Err(_) => {
+        Err(err) => {
             // Fall back to IPv4 if IPv6 is not available (common on Windows)
+            warn!(
+                "Failed to bind UDP socket on IPv6 {}: {}. Falling back to IPv4",
+                bind_addr_v6, err
+            );
             let bind_addr_v4 = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0));
             bind_udp_socket_addr(bind_addr_v4, "UDP socket").map_err(map_io)
         }

--- a/crates/slipstream-client/src/runtime/setup.rs
+++ b/crates/slipstream-client/src/runtime/setup.rs
@@ -1,8 +1,7 @@
 use crate::error::ClientError;
 use slipstream_core::net::{bind_first_resolved, bind_tcp_listener_addr, bind_udp_socket_addr};
-use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
-use tokio::net::{lookup_host, TcpListener as TokioTcpListener, UdpSocket as TokioUdpSocket};
+use tokio::net::{TcpListener as TokioTcpListener, UdpSocket as TokioUdpSocket};
 use tracing::warn;
 
 pub(crate) fn compute_mtu(domain_len: usize) -> Result<u32, ClientError> {

--- a/crates/slipstream-client/src/runtime/setup.rs
+++ b/crates/slipstream-client/src/runtime/setup.rs
@@ -1,7 +1,9 @@
 use crate::error::ClientError;
 use slipstream_core::net::{bind_first_resolved, bind_tcp_listener_addr, bind_udp_socket_addr};
-use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
-use tokio::net::{TcpListener as TokioTcpListener, UdpSocket as TokioUdpSocket};
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use tokio::net::{lookup_host, TcpListener as TokioTcpListener, UdpSocket as TokioUdpSocket};
+use tracing::warn;
 
 pub(crate) fn compute_mtu(domain_len: usize) -> Result<u32, ClientError> {
     if domain_len >= 240 {
@@ -19,8 +21,16 @@ pub(crate) fn compute_mtu(domain_len: usize) -> Result<u32, ClientError> {
 }
 
 pub(crate) async fn bind_udp_socket() -> Result<TokioUdpSocket, ClientError> {
-    let bind_addr = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0));
-    bind_udp_socket_addr(bind_addr, "UDP socket").map_err(map_io)
+    // Try IPv6 dual-stack first (works on most systems), fall back to IPv4
+    let bind_addr_v6 = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0));
+    match bind_udp_socket_addr(bind_addr_v6, "UDP socket") {
+        Ok(socket) => Ok(socket),
+        Err(_) => {
+            // Fall back to IPv4 if IPv6 is not available (common on Windows)
+            let bind_addr_v4 = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0));
+            bind_udp_socket_addr(bind_addr_v4, "UDP socket").map_err(map_io)
+        }
+    }
 }
 
 pub(crate) async fn bind_tcp_listener(

--- a/crates/slipstream-client/src/streams/callback.rs
+++ b/crates/slipstream-client/src/streams/callback.rs
@@ -113,10 +113,8 @@ pub(crate) unsafe extern "C" fn client_callback(
                 state.ready
             );
         }
-        picoquic_call_back_event_t::picoquic_callback_prepare_to_send => {
-            if !bytes.is_null() {
-                let _ = picoquic_provide_stream_data_buffer(bytes as *mut _, 0, 0, 0);
-            }
+        picoquic_call_back_event_t::picoquic_callback_prepare_to_send if !bytes.is_null() => {
+            let _ = picoquic_provide_stream_data_buffer(bytes as *mut _, 0, 0, 0);
         }
         picoquic_call_back_event_t::picoquic_callback_path_available => {
             state.path_events.push(PathEvent::Available(stream_id));

--- a/crates/slipstream-core/src/net.rs
+++ b/crates/slipstream-core/src/net.rs
@@ -5,10 +5,7 @@ use tokio::net::{lookup_host, TcpListener as TokioTcpListener, UdpSocket as Toki
 
 pub fn is_transient_udp_error(err: &Error) -> bool {
     match err.kind() {
-        ErrorKind::WouldBlock
-        | ErrorKind::TimedOut
-        | ErrorKind::Interrupted
-        | ErrorKind::ConnectionReset => {
+        ErrorKind::WouldBlock | ErrorKind::TimedOut | ErrorKind::Interrupted => {
             return true;
         }
         _ => {}
@@ -190,5 +187,12 @@ mod tests {
         let err = Error::from_raw_os_error(libc::EAFNOSUPPORT);
 
         assert!(is_ipv6_unavailable_error(&err));
+    }
+
+    #[test]
+    fn connection_reset_is_not_transient_udp_error() {
+        let err = Error::new(ErrorKind::ConnectionReset, "connection reset");
+
+        assert!(!is_transient_udp_error(&err));
     }
 }

--- a/crates/slipstream-core/src/net.rs
+++ b/crates/slipstream-core/src/net.rs
@@ -5,16 +5,32 @@ use tokio::net::{lookup_host, TcpListener as TokioTcpListener, UdpSocket as Toki
 
 pub fn is_transient_udp_error(err: &Error) -> bool {
     match err.kind() {
-        ErrorKind::WouldBlock | ErrorKind::TimedOut | ErrorKind::Interrupted => {
+        ErrorKind::WouldBlock
+        | ErrorKind::TimedOut
+        | ErrorKind::Interrupted
+        | ErrorKind::ConnectionReset => {
             return true;
         }
         _ => {}
     }
 
-    matches!(
-        err.raw_os_error(),
-        Some(code) if code == libc::ENETUNREACH || code == libc::EHOSTUNREACH
-    )
+    #[cfg(not(windows))]
+    {
+        matches!(
+            err.raw_os_error(),
+            Some(code) if code == libc::ENETUNREACH || code == libc::EHOSTUNREACH
+        )
+    }
+    #[cfg(windows)]
+    {
+        // Windows uses WinSock error codes: WSAENETUNREACH = 10051, WSAEHOSTUNREACH = 10065
+        const WSAENETUNREACH: i32 = 10051;
+        const WSAEHOSTUNREACH: i32 = 10065;
+        matches!(
+            err.raw_os_error(),
+            Some(code) if code == WSAENETUNREACH || code == WSAEHOSTUNREACH
+        )
+    }
 }
 
 pub async fn bind_first_resolved<T, F>(

--- a/crates/slipstream-core/src/net.rs
+++ b/crates/slipstream-core/src/net.rs
@@ -116,7 +116,9 @@ pub fn is_ipv6_unavailable_error(err: &Error) -> bool {
 
 #[cfg(windows)]
 fn is_ipv6_unavailable_error_code(code: i32) -> bool {
-    code == libc::WSAEAFNOSUPPORT || code == libc::WSAEPROTONOSUPPORT
+    const WSAEAFNOSUPPORT: i32 = 10047;
+    const WSAEPROTONOSUPPORT: i32 = 10043;
+    code == WSAEAFNOSUPPORT || code == WSAEPROTONOSUPPORT
 }
 
 #[cfg(not(windows))]
@@ -183,7 +185,7 @@ mod tests {
     #[test]
     fn recognizes_platform_ipv6_unavailable_error() {
         #[cfg(windows)]
-        let err = Error::from_raw_os_error(libc::WSAEAFNOSUPPORT);
+        let err = Error::from_raw_os_error(10047);
         #[cfg(not(windows))]
         let err = Error::from_raw_os_error(libc::EAFNOSUPPORT);
 

--- a/crates/slipstream-ffi/Cargo.toml
+++ b/crates/slipstream-ffi/Cargo.toml
@@ -12,9 +12,11 @@ cc = "1.0"
 
 [dependencies]
 libc = "0.2"
-winapi = { version = "0.3", features = ["winsock2", "ws2def", "ws2ipdef"] }
 openssl-sys = { version = "0.9", optional = true, features = ["vendored"] }
 slipstream-core = { path = "../slipstream-core" }
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winsock2", "ws2def", "ws2ipdef"] }
 
 [features]
 default = []

--- a/crates/slipstream-ffi/Cargo.toml
+++ b/crates/slipstream-ffi/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 repository = "https://github.com/Mygod/slipstream-rust"
 readme = "../../README.md"
 
+[build-dependencies]
+cc = "1.0"
+
 [dependencies]
 libc = "0.2"
 winapi = { version = "0.3", features = ["winsock2", "ws2def", "ws2ipdef"] }

--- a/crates/slipstream-ffi/Cargo.toml
+++ b/crates/slipstream-ffi/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../../README.md"
 
 [dependencies]
 libc = "0.2"
+winapi = { version = "0.3", features = ["winsock2", "ws2def", "ws2ipdef"] }
 openssl-sys = { version = "0.9", optional = true, features = ["vendored"] }
 slipstream-core = { path = "../slipstream-core" }
 

--- a/crates/slipstream-ffi/build.rs
+++ b/crates/slipstream-ffi/build.rs
@@ -243,6 +243,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !target.contains("android") {
         if is_windows {
             println!("cargo:rustc-link-lib=dylib=ws2_32");
+            println!("cargo:rustc-link-lib=dylib=bcrypt");
         } else {
             println!("cargo:rustc-link-lib=dylib=pthread");
         }

--- a/crates/slipstream-ffi/build.rs
+++ b/crates/slipstream-ffi/build.rs
@@ -226,17 +226,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if cfg!(feature = "openssl-static") {
             println!("cargo:rustc-link-lib=static=ssl");
             println!("cargo:rustc-link-lib=static=crypto");
-        } else {
-            if is_windows {
-                if let Ok(openssl_lib_dir) = env::var("OPENSSL_LIB_DIR") {
-                    println!("cargo:rustc-link-search=native={}", openssl_lib_dir);
-                }
-                println!("cargo:rustc-link-lib=dylib=libssl");
-                println!("cargo:rustc-link-lib=dylib=libcrypto");
-            } else {
-                println!("cargo:rustc-link-lib=dylib=ssl");
-                println!("cargo:rustc-link-lib=dylib=crypto");
+        } else if is_windows {
+            if let Ok(openssl_lib_dir) = env::var("OPENSSL_LIB_DIR") {
+                println!("cargo:rustc-link-search=native={}", openssl_lib_dir);
             }
+            println!("cargo:rustc-link-lib=dylib=libssl");
+            println!("cargo:rustc-link-lib=dylib=libcrypto");
+        } else {
+            println!("cargo:rustc-link-lib=dylib=ssl");
+            println!("cargo:rustc-link-lib=dylib=crypto");
         }
     }
 

--- a/crates/slipstream-ffi/build.rs
+++ b/crates/slipstream-ffi/build.rs
@@ -84,8 +84,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let openssl_paths = resolve_openssl_paths();
+    let host = env::var("HOST").unwrap_or_default();
     let target = env::var("TARGET").unwrap_or_default();
     let is_windows = target.contains("windows") || target.contains("pc-windows");
+    let host_is_windows = host.contains("windows") || host.contains("pc-windows");
     let auto_build = env_flag("PICOQUIC_AUTO_BUILD", true);
     let explicit_picoquic_include = env::var_os("PICOQUIC_INCLUDE_DIR").is_some();
     let explicit_picoquic_lib = env::var_os("PICOQUIC_LIB_DIR").is_some();
@@ -93,6 +95,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut picoquic_include_dir = locate_picoquic_include_dir();
     let mut picoquic_lib_dir = locate_picoquic_lib_dir();
     let mut picotls_include_dir = locate_picotls_include_dir();
+
+    if is_windows && !host_is_windows {
+        return Err(
+            "Windows targets are only supported from a Windows host. Cross-building picoquic/picotls from Linux is unsupported in this repo."
+                .into(),
+        );
+    }
+
+    if is_windows
+        && auto_build
+        && !explicit_picoquic_include_lib
+        && (picoquic_include_dir.is_none() || picoquic_lib_dir.is_none())
+    {
+        return Err(
+            "Automatic picoquic builds are unsupported for Windows targets. Run `pwsh -File ./scripts/build_picoquic_windows.ps1` on Windows, or set PICOQUIC_INCLUDE_DIR, PICOQUIC_LIB_DIR, and PICOTLS_INCLUDE_DIR yourself."
+                .into(),
+        );
+    }
 
     if auto_build
         && !explicit_picoquic_include_lib
@@ -119,15 +139,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let picoquic_include_dir = picoquic_include_dir.ok_or(
-        "Missing picoquic headers; set PICOQUIC_DIR or PICOQUIC_INCLUDE_DIR (default: vendor/picoquic).",
-    )?;
-    let picoquic_lib_dir = picoquic_lib_dir.ok_or(
-        "Missing picoquic build artifacts; run ./scripts/build_picoquic.sh or set PICOQUIC_BUILD_DIR/PICOQUIC_LIB_DIR.",
-    )?;
-    let picotls_include_dir = picotls_include_dir.ok_or(
-        "Missing picotls headers; set PICOTLS_INCLUDE_DIR or build picoquic with PICOQUIC_FETCH_PTLS=ON.",
-    )?;
+    let picoquic_include_dir = picoquic_include_dir
+        .ok_or_else(|| missing_picoquic_headers_message(is_windows).to_string())?;
+    let picoquic_lib_dir =
+        picoquic_lib_dir.ok_or_else(|| missing_picoquic_libs_message(is_windows).to_string())?;
+    let picotls_include_dir = picotls_include_dir
+        .ok_or_else(|| missing_picotls_headers_message(is_windows).to_string())?;
 
     let cc = resolve_cc(&target);
     let ar = resolve_ar(&target, &cc);
@@ -196,14 +213,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rustc-link-search=native={}", out_dir.display());
     println!("cargo:rustc-link-lib=static=slipstream_client_objs");
 
-    let picoquic_libs = resolve_picoquic_libs(&picoquic_lib_dir).ok_or(
-        "Missing picoquic build artifacts; run ./scripts/build_picoquic.sh or set PICOQUIC_BUILD_DIR/PICOQUIC_LIB_DIR.",
-    )?;
+    let picoquic_libs = resolve_picoquic_libs(&picoquic_lib_dir)
+        .ok_or_else(|| missing_picoquic_libs_message(is_windows).to_string())?;
+    if is_windows && !has_windows_minicrypto_support_libs(&picoquic_libs.libs) {
+        return Err(
+            "Missing Windows picotls dependency libraries. Provide upstream cifra.lib and microecc.lib (preferred) or picotls-minicrypto-deps.lib in PICOQUIC_LIB_DIR."
+                .into(),
+        );
+    }
     for dir in picoquic_libs.search_dirs {
         println!("cargo:rustc-link-search=native={}", dir.display());
     }
     for lib in picoquic_libs.libs {
-        println!("cargo:rustc-link-lib=static={}", lib);
+        if is_windows && needs_whole_archive_windows(lib) {
+            println!("cargo:rustc-link-lib=static:+whole-archive={}", lib);
+        } else {
+            println!("cargo:rustc-link-lib=static={}", lib);
+        }
     }
 
     if !cfg!(feature = "openssl-vendored") {
@@ -258,8 +284,66 @@ fn push_unique_dir(dirs: &mut Vec<PathBuf>, dir: PathBuf) {
     }
 }
 
+fn missing_picoquic_headers_message(is_windows: bool) -> &'static str {
+    if is_windows {
+        "Missing picoquic headers for Windows. Set PICOQUIC_INCLUDE_DIR to the upstream picoquic headers you built on Windows."
+    } else {
+        "Missing picoquic headers; set PICOQUIC_DIR or PICOQUIC_INCLUDE_DIR (default: vendor/picoquic)."
+    }
+}
+
+fn missing_picoquic_libs_message(is_windows: bool) -> &'static str {
+    if is_windows {
+        "Missing picoquic build artifacts for Windows. Run `pwsh -File ./scripts/build_picoquic_windows.ps1`, or set PICOQUIC_INCLUDE_DIR, PICOQUIC_LIB_DIR, and PICOTLS_INCLUDE_DIR."
+    } else {
+        "Missing picoquic build artifacts; run ./scripts/build_picoquic.sh or set PICOQUIC_BUILD_DIR/PICOQUIC_LIB_DIR."
+    }
+}
+
+fn missing_picotls_headers_message(is_windows: bool) -> &'static str {
+    if is_windows {
+        "Missing picotls headers for Windows. Run `pwsh -File ./scripts/build_picoquic_windows.ps1`, or set PICOTLS_INCLUDE_DIR to your picotls include directory."
+    } else {
+        "Missing picotls headers; set PICOTLS_INCLUDE_DIR or build picoquic with PICOQUIC_FETCH_PTLS=ON."
+    }
+}
+
 fn add_parent_dir(dirs: &mut Vec<PathBuf>, path: &Path) {
     if let Some(parent) = path.parent() {
         push_unique_dir(dirs, parent.to_path_buf());
     }
+}
+
+fn needs_whole_archive_windows(lib: &str) -> bool {
+    matches!(
+        lib,
+        "picoquic_core"
+            | "picoquic-core"
+            | "picoquic"
+            | "cifra"
+            | "microecc"
+            | "picotls_core"
+            | "picotls-core"
+            | "picotls_openssl"
+            | "picotls-openssl"
+            | "picotls_minicrypto"
+            | "picotls-minicrypto"
+            | "picotls_fusion"
+            | "picotls-fusion"
+    )
+}
+
+fn has_windows_minicrypto_support_libs(libs: &[&str]) -> bool {
+    if !has_any_lib(libs, &["picotls_minicrypto", "picotls-minicrypto"]) {
+        return true;
+    }
+
+    has_any_lib(
+        libs,
+        &["picotls_minicrypto_deps", "picotls-minicrypto-deps"],
+    ) || (has_any_lib(libs, &["cifra"]) && has_any_lib(libs, &["microecc"]))
+}
+
+fn has_any_lib(libs: &[&str], names: &[&str]) -> bool {
+    libs.iter().any(|lib| names.contains(lib))
 }

--- a/crates/slipstream-ffi/build.rs
+++ b/crates/slipstream-ffi/build.rs
@@ -31,6 +31,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR");
     println!("cargo:rerun-if-env-changed=OPENSSL_CRYPTO_LIBRARY");
     println!("cargo:rerun-if-env-changed=OPENSSL_SSL_LIBRARY");
+    println!("cargo:rerun-if-env-changed=OPENSSL_LIBS");
+    println!("cargo:rerun-if-env-changed=OPENSSL_STATIC");
     println!("cargo:rerun-if-env-changed=OPENSSL_USE_STATIC_LIBS");
     println!("cargo:rerun-if-env-changed=OPENSSL_NO_VENDOR");
     println!("cargo:rerun-if-env-changed=DEP_OPENSSL_ROOT");
@@ -89,6 +91,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let is_windows = target.contains("windows") || target.contains("pc-windows");
     let host_is_windows = host.contains("windows") || host.contains("pc-windows");
     let auto_build = env_flag("PICOQUIC_AUTO_BUILD", true);
+    let openssl_static = cfg!(feature = "openssl-static") || env_flag("OPENSSL_STATIC", false);
     let explicit_picoquic_include = env::var_os("PICOQUIC_INCLUDE_DIR").is_some();
     let explicit_picoquic_lib = env::var_os("PICOQUIC_LIB_DIR").is_some();
     let explicit_picoquic_include_lib = explicit_picoquic_include || explicit_picoquic_lib;
@@ -255,9 +258,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         for dir in openssl_search_dirs {
             println!("cargo:rustc-link-search=native={}", dir.display());
         }
-        if cfg!(feature = "openssl-static") {
-            println!("cargo:rustc-link-lib=static=ssl");
-            println!("cargo:rustc-link-lib=static=crypto");
+        if openssl_static {
+            for lib in openssl_link_libs(is_windows) {
+                println!("cargo:rustc-link-lib=static={}", lib);
+            }
+            if is_windows {
+                println!("cargo:rustc-link-lib=dylib=gdi32");
+                println!("cargo:rustc-link-lib=dylib=user32");
+                println!("cargo:rustc-link-lib=dylib=crypt32");
+                println!("cargo:rustc-link-lib=dylib=advapi32");
+            }
         } else if is_windows {
             if let Ok(openssl_lib_dir) = env::var("OPENSSL_LIB_DIR") {
                 println!("cargo:rustc-link-search=native={}", openssl_lib_dir);
@@ -282,6 +292,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn openssl_link_libs(is_windows: bool) -> Vec<String> {
+    if let Ok(libs) = env::var("OPENSSL_LIBS") {
+        let libs = libs
+            .split(':')
+            .filter(|lib| !lib.is_empty())
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        if !libs.is_empty() {
+            return libs;
+        }
+    }
+
+    if is_windows {
+        vec!["libssl".to_owned(), "libcrypto".to_owned()]
+    } else {
+        vec!["ssl".to_owned(), "crypto".to_owned()]
+    }
 }
 
 fn push_unique_dir(dirs: &mut Vec<PathBuf>, dir: PathBuf) {

--- a/crates/slipstream-ffi/build.rs
+++ b/crates/slipstream-ffi/build.rs
@@ -96,6 +96,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut picoquic_lib_dir = locate_picoquic_lib_dir();
     let mut picotls_include_dir = locate_picotls_include_dir();
 
+    if is_windows && target != "x86_64-pc-windows-msvc" {
+        return Err("Windows builds are only supported for x86_64-pc-windows-msvc.".into());
+    }
+
     if is_windows && !host_is_windows {
         return Err(
             "Windows targets are only supported from a Windows host. Cross-building picoquic/picotls from Linux is unsupported in this repo."
@@ -146,7 +150,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let picotls_include_dir = picotls_include_dir
         .ok_or_else(|| missing_picotls_headers_message(is_windows).to_string())?;
 
-    let cc = resolve_cc(&target);
+    let cc = resolve_cc(&target)?;
     let ar = resolve_ar(&target, &cc);
     let mut object_paths = Vec::with_capacity(1);
 
@@ -209,7 +213,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     object_paths.push(picotls_layout_obj);
 
     let archive = out_dir.join("libslipstream_client_objs.a");
-    create_archive(&ar, &archive, &object_paths)?;
+    create_archive(&ar, &cc, &archive, &object_paths)?;
     println!("cargo:rustc-link-search=native={}", out_dir.display());
     println!("cargo:rustc-link-lib=static=slipstream_client_objs");
 
@@ -225,8 +229,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:rustc-link-search=native={}", dir.display());
     }
     for lib in picoquic_libs.libs {
-        if is_windows && needs_whole_archive_windows(lib) {
-            println!("cargo:rustc-link-lib=static:+whole-archive={}", lib);
+        if is_windows {
+            // MSVC needs the upstream archives on the final link line; bundling can
+            // leave the rlib without the picoquic objects referenced by Rust tests.
+            println!("cargo:rustc-link-lib=static:-bundle={}", lib);
         } else {
             println!("cargo:rustc-link-lib=static={}", lib);
         }
@@ -312,25 +318,6 @@ fn add_parent_dir(dirs: &mut Vec<PathBuf>, path: &Path) {
     if let Some(parent) = path.parent() {
         push_unique_dir(dirs, parent.to_path_buf());
     }
-}
-
-fn needs_whole_archive_windows(lib: &str) -> bool {
-    matches!(
-        lib,
-        "picoquic_core"
-            | "picoquic-core"
-            | "picoquic"
-            | "cifra"
-            | "microecc"
-            | "picotls_core"
-            | "picotls-core"
-            | "picotls_openssl"
-            | "picotls-openssl"
-            | "picotls_minicrypto"
-            | "picotls-minicrypto"
-            | "picotls_fusion"
-            | "picotls-fusion"
-    )
 }
 
 fn has_windows_minicrypto_support_libs(libs: &[&str]) -> bool {

--- a/crates/slipstream-ffi/build.rs
+++ b/crates/slipstream-ffi/build.rs
@@ -94,7 +94,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let explicit_picoquic_lib = env::var_os("PICOQUIC_LIB_DIR").is_some();
     let explicit_picoquic_include_lib = explicit_picoquic_include || explicit_picoquic_lib;
     let mut picoquic_include_dir = locate_picoquic_include_dir();
-    let mut picoquic_lib_dir = locate_picoquic_lib_dir();
+    let mut picoquic_lib_dir = locate_picoquic_lib_dir(is_windows);
     let mut picotls_include_dir = locate_picotls_include_dir();
 
     if is_windows
@@ -114,7 +114,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         build_picoquic(&openssl_paths, &target)?;
         picoquic_include_dir = locate_picoquic_include_dir();
-        picoquic_lib_dir = locate_picoquic_lib_dir();
+        picoquic_lib_dir = locate_picoquic_lib_dir(is_windows);
         picotls_include_dir = locate_picotls_include_dir();
     }
 

--- a/crates/slipstream-ffi/build.rs
+++ b/crates/slipstream-ffi/build.rs
@@ -86,10 +86,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let openssl_paths = resolve_openssl_paths();
-    let host = env::var("HOST").unwrap_or_default();
     let target = env::var("TARGET").unwrap_or_default();
     let is_windows = target.contains("windows") || target.contains("pc-windows");
-    let host_is_windows = host.contains("windows") || host.contains("pc-windows");
     let auto_build = env_flag("PICOQUIC_AUTO_BUILD", true);
     let openssl_static = cfg!(feature = "openssl-static") || env_flag("OPENSSL_STATIC", false);
     let explicit_picoquic_include = env::var_os("PICOQUIC_INCLUDE_DIR").is_some();
@@ -98,17 +96,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut picoquic_include_dir = locate_picoquic_include_dir();
     let mut picoquic_lib_dir = locate_picoquic_lib_dir();
     let mut picotls_include_dir = locate_picotls_include_dir();
-
-    if is_windows && target != "x86_64-pc-windows-msvc" {
-        return Err("Windows builds are only supported for x86_64-pc-windows-msvc.".into());
-    }
-
-    if is_windows && !host_is_windows {
-        return Err(
-            "Windows targets are only supported from a Windows host. Cross-building picoquic/picotls from Linux is unsupported in this repo."
-                .into(),
-        );
-    }
 
     if is_windows
         && auto_build

--- a/crates/slipstream-ffi/build/android.rs
+++ b/crates/slipstream-ffi/build/android.rs
@@ -1,7 +1,8 @@
-use std::path::PathBuf;
-use std::process::Command;
+use crate::cc::CcTool;
 
-pub(crate) fn maybe_link_android_builtins(target: &str, cc: &str) {
+use std::path::PathBuf;
+
+pub(crate) fn maybe_link_android_builtins(target: &str, cc: &CcTool) {
     let builtins = match android_builtins_name(target) {
         Some(name) => name,
         None => return,
@@ -32,11 +33,8 @@ fn android_builtins_name(target: &str) -> Option<&'static str> {
     }
 }
 
-fn clang_builtins_path(cc: &str, builtins: &str) -> Option<PathBuf> {
-    let output = Command::new(cc)
-        .arg("-print-libgcc-file-name")
-        .output()
-        .ok()?;
+fn clang_builtins_path(cc: &CcTool, builtins: &str) -> Option<PathBuf> {
+    let output = cc.command().arg("-print-libgcc-file-name").output().ok()?;
     if !output.status.success() {
         return None;
     }

--- a/crates/slipstream-ffi/build/cc.rs
+++ b/crates/slipstream-ffi/build/cc.rs
@@ -4,12 +4,40 @@ use std::process::Command;
 
 pub(crate) fn resolve_cc(target: &str) -> String {
     if target.contains("android") {
-        env::var("RUST_ANDROID_GRADLE_CC")
+        return env::var("RUST_ANDROID_GRADLE_CC")
             .or_else(|_| env::var("CC"))
-            .unwrap_or_else(|_| "cc".to_string())
-    } else {
-        env::var("CC").unwrap_or_else(|_| "cc".to_string())
+            .unwrap_or_else(|_| "cc".to_string());
     }
+    
+    if let Ok(cc) = env::var("CC") {
+        return cc;
+    }
+    
+    if target.contains("windows") || target.contains("pc-windows") {
+        let gcc_candidates = [
+            "C:\\Strawberry\\c\\bin\\gcc.exe",
+            "C:\\mingw64\\bin\\gcc.exe",
+            "C:\\msys64\\mingw64\\bin\\gcc.exe",
+        ];
+        
+        for candidate in &gcc_candidates {
+            if Path::new(candidate).exists() {
+                return candidate.to_string();
+            }
+        }
+    }
+    
+    let builder = cc::Build::new();
+    let compiler = builder.get_compiler();
+    let path = compiler.path();
+    let path_str = path.to_string_lossy().to_string();
+    
+    // Verify the compiler actually exists
+    if !path.exists() {
+        panic!("Compiler not found at: {}. Please install a C compiler (MinGW-w64, MSVC Build Tools, or Strawberry Perl).", path_str);
+    }
+    
+    path_str
 }
 
 pub(crate) fn resolve_ar(target: &str, cc: &str) -> String {
@@ -21,6 +49,21 @@ pub(crate) fn resolve_ar(target: &str, cc: &str) -> String {
     if let Ok(ar) = env::var("AR") {
         return ar;
     }
+    if target.contains("windows") || target.contains("pc-windows") {
+        if cc.contains("gcc") || cc.contains("mingw") {
+            if let Some(gcc_dir) = Path::new(cc).parent() {
+                let ar_path = gcc_dir.join("ar.exe");
+                if ar_path.exists() {
+                    return ar_path.to_string_lossy().to_string();
+                }
+            }
+            return "ar".to_string();
+        }
+        if target.contains("msvc") {
+            return "lib.exe".to_string();
+        }
+    }
+    // For non-Windows targets, look for llvm-ar or ar in the compiler directory
     if let Some(dir) = Path::new(cc).parent() {
         let candidate = dir.join("llvm-ar");
         if candidate.exists() {
@@ -39,14 +82,34 @@ pub(crate) fn create_archive(
     archive: &Path,
     objects: &[PathBuf],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut command = Command::new(ar);
-    command.arg("crus").arg(archive);
-    for obj in objects {
-        command.arg(obj);
-    }
-    let status = command.status()?;
-    if !status.success() {
-        return Err("Failed to create static archive for slipstream objects.".into());
+    let target = env::var("TARGET").unwrap_or_default();
+    let is_windows = target.contains("windows") || target.contains("pc-windows");
+    
+    if is_windows && ar.contains("lib.exe") && ar != "ar" {
+        // MSVC: use lib.exe
+        let mut lib_cmd = Command::new("lib.exe");
+        lib_cmd
+            .arg("/OUT:")
+            .arg(archive)
+            .arg("/NOLOGO");
+        for obj in objects {
+            lib_cmd.arg(obj);
+        }
+        let status = lib_cmd.status()?;
+        if !status.success() {
+            return Err("Failed to create static archive for slipstream objects.".into());
+        }
+    } else {
+        // GCC/Clang/MinGW: use ar
+        let mut command = Command::new(ar);
+        command.arg("crus").arg(archive);
+        for obj in objects {
+            command.arg(obj);
+        }
+        let status = command.status()?;
+        if !status.success() {
+            return Err("Failed to create static archive for slipstream objects.".into());
+        }
     }
     Ok(())
 }
@@ -57,15 +120,30 @@ pub(crate) fn compile_cc(
     output: &Path,
     picoquic_include_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let status = Command::new(cc)
-        .arg("-c")
-        .arg("-fPIC")
-        .arg(source)
-        .arg("-o")
-        .arg(output)
-        .arg("-I")
-        .arg(picoquic_include_dir)
-        .status()?;
+    let target = env::var("TARGET").unwrap_or_default();
+    let is_windows = target.contains("windows") || target.contains("pc-windows");
+    let is_gcc = cc.contains("gcc") || cc.contains("mingw");
+    
+    let mut cmd = Command::new(cc);
+    
+    if is_windows && !is_gcc {
+        // MSVC: cl.exe /c /Fo:output source.c /I include_dir
+        cmd.arg("/c")
+           .arg(format!("/Fo:{}", output.display()))
+           .arg(source)
+           .arg(format!("/I{}", picoquic_include_dir.display()));
+    } else {
+        // GCC/Clang: cc -c -fPIC -o output source.c -I include_dir
+        cmd.arg("-c")
+           .arg("-fPIC")
+           .arg("-o")
+           .arg(output)
+           .arg(source)
+           .arg("-I")
+           .arg(picoquic_include_dir);
+    }
+    
+    let status = cmd.status()?;
     if !status.success() {
         return Err(format!("Failed to compile {}.", source.display()).into());
     }
@@ -78,17 +156,33 @@ pub(crate) fn compile_cc_with_includes(
     output: &Path,
     include_dirs: &[&Path],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut command = Command::new(cc);
-    command
-        .arg("-c")
-        .arg("-fPIC")
-        .arg(source)
-        .arg("-o")
-        .arg(output);
-    for dir in include_dirs {
-        command.arg("-I").arg(dir);
+    let target = env::var("TARGET").unwrap_or_default();
+    let is_windows = target.contains("windows") || target.contains("pc-windows");
+    let is_gcc = cc.contains("gcc") || cc.contains("mingw");
+    
+    let mut cmd = Command::new(cc);
+    
+    if is_windows && !is_gcc {
+        // MSVC: cl.exe /c /Fo:output source.c /I include_dir1 /I include_dir2
+        cmd.arg("/c")
+           .arg(format!("/Fo:{}", output.display()))
+           .arg(source);
+        for dir in include_dirs {
+            cmd.arg(format!("/I{}", dir.display()));
+        }
+    } else {
+        // GCC/Clang: cc -c -fPIC -o output source.c -I include_dir1 -I include_dir2
+        cmd.arg("-c")
+           .arg("-fPIC")
+           .arg("-o")
+           .arg(output)
+           .arg(source);
+        for dir in include_dirs {
+            cmd.arg("-I").arg(dir);
+        }
     }
-    let status = command.status()?;
+    
+    let status = cmd.status()?;
     if !status.success() {
         return Err(format!("Failed to compile {}.", source.display()).into());
     }

--- a/crates/slipstream-ffi/build/cc.rs
+++ b/crates/slipstream-ffi/build/cc.rs
@@ -1,46 +1,70 @@
 use std::env;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-pub(crate) fn resolve_cc(target: &str) -> String {
-    if target.contains("android") {
-        return env::var("RUST_ANDROID_GRADLE_CC")
-            .or_else(|_| env::var("CC"))
-            .unwrap_or_else(|_| "cc".to_string());
-    }
+pub(crate) struct CcTool {
+    path: PathBuf,
+    args: Vec<OsString>,
+    env: Vec<(OsString, OsString)>,
+}
 
-    if let Ok(cc) = env::var("CC") {
-        return cc;
-    }
-
-    if target.contains("windows") || target.contains("pc-windows") {
-        let gcc_candidates = [
-            "C:\\Strawberry\\c\\bin\\gcc.exe",
-            "C:\\mingw64\\bin\\gcc.exe",
-            "C:\\msys64\\mingw64\\bin\\gcc.exe",
-        ];
-
-        for candidate in &gcc_candidates {
-            if Path::new(candidate).exists() {
-                return candidate.to_string();
-            }
+impl CcTool {
+    fn from_path(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            args: Vec::new(),
+            env: Vec::new(),
         }
     }
 
-    let builder = cc::Build::new();
-    let compiler = builder.get_compiler();
-    let path = compiler.path();
-    let path_str = path.to_string_lossy().to_string();
-
-    // Verify the compiler actually exists
-    if !path.exists() {
-        panic!("Compiler not found at: {}. Please install a C compiler (MinGW-w64, MSVC Build Tools, or Strawberry Perl).", path_str);
+    fn from_tool(tool: cc::Tool) -> Self {
+        Self {
+            path: tool.path().to_path_buf(),
+            args: tool.args().to_vec(),
+            env: tool.env().to_vec(),
+        }
     }
 
-    path_str
+    pub(crate) fn command(&self) -> Command {
+        let mut command = Command::new(&self.path);
+        command.args(&self.args);
+        for (name, value) in &self.env {
+            command.env(name, value);
+        }
+        command
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn env(&self) -> &[(OsString, OsString)] {
+        &self.env
+    }
 }
 
-pub(crate) fn resolve_ar(target: &str, cc: &str) -> String {
+pub(crate) fn resolve_cc(target: &str) -> Result<CcTool, Box<dyn std::error::Error>> {
+    if target.contains("android") {
+        return Ok(CcTool::from_path(
+            env::var("RUST_ANDROID_GRADLE_CC")
+                .or_else(|_| env::var("CC"))
+                .unwrap_or_else(|_| "cc".to_string()),
+        ));
+    }
+
+    if let Ok(cc) = env::var("CC") {
+        return Ok(CcTool::from_path(cc));
+    }
+
+    let mut builder = cc::Build::new();
+    builder.target(target);
+    let compiler = builder.get_compiler();
+
+    Ok(CcTool::from_tool(compiler))
+}
+
+pub(crate) fn resolve_ar(target: &str, cc: &CcTool) -> String {
     if target.contains("android") {
         if let Ok(ar) = env::var("RUST_ANDROID_GRADLE_AR") {
             return ar;
@@ -49,22 +73,11 @@ pub(crate) fn resolve_ar(target: &str, cc: &str) -> String {
     if let Ok(ar) = env::var("AR") {
         return ar;
     }
-    if target.contains("windows") || target.contains("pc-windows") {
-        if cc.contains("gcc") || cc.contains("mingw") {
-            if let Some(gcc_dir) = Path::new(cc).parent() {
-                let ar_path = gcc_dir.join("ar.exe");
-                if ar_path.exists() {
-                    return ar_path.to_string_lossy().to_string();
-                }
-            }
-            return "ar".to_string();
-        }
-        if target.contains("msvc") {
-            return "lib.exe".to_string();
-        }
+    if (target.contains("windows") || target.contains("pc-windows")) && target.contains("msvc") {
+        return "lib.exe".to_string();
     }
     // For non-Windows targets, look for llvm-ar or ar in the compiler directory
-    if let Some(dir) = Path::new(cc).parent() {
+    if let Some(dir) = cc.path().parent() {
         let candidate = dir.join("llvm-ar");
         if candidate.exists() {
             return candidate.to_string_lossy().into_owned();
@@ -79,16 +92,21 @@ pub(crate) fn resolve_ar(target: &str, cc: &str) -> String {
 
 pub(crate) fn create_archive(
     ar: &str,
+    cc: &CcTool,
     archive: &Path,
     objects: &[PathBuf],
 ) -> Result<(), Box<dyn std::error::Error>> {
     let target = env::var("TARGET").unwrap_or_default();
     let is_windows = target.contains("windows") || target.contains("pc-windows");
 
-    if is_windows && ar.contains("lib.exe") && ar != "ar" {
-        // MSVC: use lib.exe
-        let mut lib_cmd = Command::new("lib.exe");
-        lib_cmd.arg("/OUT:").arg(archive).arg("/NOLOGO");
+    if is_windows {
+        let mut lib_cmd = Command::new(ar);
+        for (name, value) in cc.env() {
+            lib_cmd.env(name, value);
+        }
+        let mut out_arg = OsString::from("/OUT:");
+        out_arg.push(archive.as_os_str());
+        lib_cmd.arg(out_arg).arg("/NOLOGO");
         for obj in objects {
             lib_cmd.arg(obj);
         }
@@ -97,7 +115,6 @@ pub(crate) fn create_archive(
             return Err("Failed to create static archive for slipstream objects.".into());
         }
     } else {
-        // GCC/Clang/MinGW: use ar
         let mut command = Command::new(ar);
         command.arg("crus").arg(archive);
         for obj in objects {
@@ -112,19 +129,17 @@ pub(crate) fn create_archive(
 }
 
 pub(crate) fn compile_cc(
-    cc: &str,
+    cc: &CcTool,
     source: &Path,
     output: &Path,
     picoquic_include_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let target = env::var("TARGET").unwrap_or_default();
     let is_windows = target.contains("windows") || target.contains("pc-windows");
-    let is_gcc = cc.contains("gcc") || cc.contains("mingw");
 
-    let mut cmd = Command::new(cc);
+    let mut cmd = cc.command();
 
-    if is_windows && !is_gcc {
-        // MSVC: cl.exe /c /Fo:output source.c /I include_dir /D_WINDOWS [/D_WINDOWS64]
+    if is_windows {
         cmd.arg("/c")
             .arg(format!("/Fo:{}", output.display()))
             .arg(source)
@@ -134,14 +149,7 @@ pub(crate) fn compile_cc(
         }
         cmd.arg(format!("/I{}", picoquic_include_dir.display()));
     } else {
-        // GCC/Clang: cc -c -fPIC -o output source.c -I include_dir [-D_WINDOWS [-D_WINDOWS64]]
         cmd.arg("-c").arg("-fPIC").arg("-o").arg(output).arg(source);
-        if is_windows {
-            cmd.arg("-D_WINDOWS");
-            if target.contains("x86_64") {
-                cmd.arg("-D_WINDOWS64");
-            }
-        }
         cmd.arg("-I").arg(picoquic_include_dir);
     }
 
@@ -153,19 +161,17 @@ pub(crate) fn compile_cc(
 }
 
 pub(crate) fn compile_cc_with_includes(
-    cc: &str,
+    cc: &CcTool,
     source: &Path,
     output: &Path,
     include_dirs: &[&Path],
 ) -> Result<(), Box<dyn std::error::Error>> {
     let target = env::var("TARGET").unwrap_or_default();
     let is_windows = target.contains("windows") || target.contains("pc-windows");
-    let is_gcc = cc.contains("gcc") || cc.contains("mingw");
 
-    let mut cmd = Command::new(cc);
+    let mut cmd = cc.command();
 
-    if is_windows && !is_gcc {
-        // MSVC: cl.exe /c /Fo:output source.c /D_WINDOWS [/D_WINDOWS64] /I dir1 /I dir2
+    if is_windows {
         cmd.arg("/c")
             .arg(format!("/Fo:{}", output.display()))
             .arg(source)
@@ -177,14 +183,7 @@ pub(crate) fn compile_cc_with_includes(
             cmd.arg(format!("/I{}", dir.display()));
         }
     } else {
-        // GCC/Clang: cc -c -fPIC -o output source.c [-D_WINDOWS [-D_WINDOWS64]] -I dir1 -I dir2
         cmd.arg("-c").arg("-fPIC").arg("-o").arg(output).arg(source);
-        if is_windows {
-            cmd.arg("-D_WINDOWS");
-            if target.contains("x86_64") {
-                cmd.arg("-D_WINDOWS64");
-            }
-        }
         for dir in include_dirs {
             cmd.arg("-I").arg(dir);
         }

--- a/crates/slipstream-ffi/build/cc.rs
+++ b/crates/slipstream-ffi/build/cc.rs
@@ -73,7 +73,7 @@ pub(crate) fn resolve_ar(target: &str, cc: &CcTool) -> String {
     if let Ok(ar) = env::var("AR") {
         return ar;
     }
-    if (target.contains("windows") || target.contains("pc-windows")) && target.contains("msvc") {
+    if target.contains("msvc") {
         return "lib.exe".to_string();
     }
     // For non-Windows targets, look for llvm-ar or ar in the compiler directory
@@ -97,9 +97,9 @@ pub(crate) fn create_archive(
     objects: &[PathBuf],
 ) -> Result<(), Box<dyn std::error::Error>> {
     let target = env::var("TARGET").unwrap_or_default();
-    let is_windows = target.contains("windows") || target.contains("pc-windows");
+    let is_msvc = target.contains("msvc");
 
-    if is_windows {
+    if is_msvc {
         let mut lib_cmd = Command::new(ar);
         for (name, value) in cc.env() {
             lib_cmd.env(name, value);
@@ -136,10 +136,11 @@ pub(crate) fn compile_cc(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let target = env::var("TARGET").unwrap_or_default();
     let is_windows = target.contains("windows") || target.contains("pc-windows");
+    let is_msvc = target.contains("msvc");
 
     let mut cmd = cc.command();
 
-    if is_windows {
+    if is_msvc {
         cmd.arg("/c")
             .arg(format!("/Fo:{}", output.display()))
             .arg(source)
@@ -149,7 +150,16 @@ pub(crate) fn compile_cc(
         }
         cmd.arg(format!("/I{}", picoquic_include_dir.display()));
     } else {
-        cmd.arg("-c").arg("-fPIC").arg("-o").arg(output).arg(source);
+        cmd.arg("-c").arg("-o").arg(output).arg(source);
+        if !is_windows {
+            cmd.arg("-fPIC");
+        }
+        if is_windows {
+            cmd.arg("-D_WINDOWS");
+            if target.contains("x86_64") {
+                cmd.arg("-D_WINDOWS64");
+            }
+        }
         cmd.arg("-I").arg(picoquic_include_dir);
     }
 
@@ -168,10 +178,11 @@ pub(crate) fn compile_cc_with_includes(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let target = env::var("TARGET").unwrap_or_default();
     let is_windows = target.contains("windows") || target.contains("pc-windows");
+    let is_msvc = target.contains("msvc");
 
     let mut cmd = cc.command();
 
-    if is_windows {
+    if is_msvc {
         cmd.arg("/c")
             .arg(format!("/Fo:{}", output.display()))
             .arg(source)
@@ -183,7 +194,16 @@ pub(crate) fn compile_cc_with_includes(
             cmd.arg(format!("/I{}", dir.display()));
         }
     } else {
-        cmd.arg("-c").arg("-fPIC").arg("-o").arg(output).arg(source);
+        cmd.arg("-c").arg("-o").arg(output).arg(source);
+        if !is_windows {
+            cmd.arg("-fPIC");
+        }
+        if is_windows {
+            cmd.arg("-D_WINDOWS");
+            if target.contains("x86_64") {
+                cmd.arg("-D_WINDOWS64");
+            }
+        }
         for dir in include_dirs {
             cmd.arg("-I").arg(dir);
         }

--- a/crates/slipstream-ffi/build/picoquic.rs
+++ b/crates/slipstream-ffi/build/picoquic.rs
@@ -28,7 +28,13 @@ pub(crate) fn build_picoquic(
         .map(PathBuf::from)
         .unwrap_or_else(|| root.join(".picoquic-build"));
 
-    let mut command = Command::new(script);
+    let mut command = if cfg!(windows) {
+        let mut cmd = Command::new("bash");
+        cmd.arg(&script);
+        cmd
+    } else {
+        Command::new(script)
+    };
     command
         .env("PICOQUIC_DIR", picoquic_dir)
         .env("PICOQUIC_BUILD_DIR", build_dir)

--- a/crates/slipstream-ffi/build/picoquic.rs
+++ b/crates/slipstream-ffi/build/picoquic.rs
@@ -29,7 +29,18 @@ pub(crate) fn build_picoquic(
         .unwrap_or_else(|| root.join(".picoquic-build"));
 
     let mut command = if cfg!(windows) {
-        let mut cmd = Command::new("bash");
+        // On Windows, find Git Bash explicitly to avoid WSL bash.exe from System32
+        let git_bash_paths = [
+            PathBuf::from(r"C:\Program Files\Git\bin\bash.exe"),
+            PathBuf::from(r"C:\Program Files\Git\usr\bin\bash.exe"),
+        ];
+
+        let bash_exe = git_bash_paths
+            .iter()
+            .find(|path| path.exists())
+            .ok_or("Git Bash not found. Please install Git for Windows.")?;
+
+        let mut cmd = Command::new(bash_exe);
         cmd.arg(&script);
         cmd
     } else {

--- a/crates/slipstream-ffi/build/picoquic.rs
+++ b/crates/slipstream-ffi/build/picoquic.rs
@@ -120,9 +120,14 @@ pub(crate) fn locate_picoquic_lib_dir() -> Option<PathBuf> {
     }
 
     if let Ok(dir) = env::var("PICOQUIC_BUILD_DIR") {
-        let candidate = PathBuf::from(&dir);
-        if has_picoquic_libs(&candidate) {
-            return Some(candidate);
+        let build_dir = PathBuf::from(&dir);
+        for candidate in windows_stage_candidates(&build_dir) {
+            if has_picoquic_libs(&candidate) {
+                return Some(candidate);
+            }
+        }
+        if has_picoquic_libs(&build_dir) {
+            return Some(build_dir);
         }
         let candidate = Path::new(&dir).join("picoquic");
         if has_picoquic_libs(&candidate) {
@@ -131,9 +136,14 @@ pub(crate) fn locate_picoquic_lib_dir() -> Option<PathBuf> {
     }
 
     if let Some(root) = locate_repo_root() {
-        let candidate = root.join(".picoquic-build");
-        if has_picoquic_libs(&candidate) {
-            return Some(candidate);
+        let build_dir = root.join(".picoquic-build");
+        for candidate in windows_stage_candidates(&build_dir) {
+            if has_picoquic_libs(&candidate) {
+                return Some(candidate);
+            }
+        }
+        if has_picoquic_libs(&build_dir) {
+            return Some(build_dir);
         }
         let candidate = root.join(".picoquic-build").join("picoquic");
         if has_picoquic_libs(&candidate) {
@@ -184,6 +194,10 @@ pub(crate) fn locate_picotls_include_dir() -> Option<PathBuf> {
             .join("_deps")
             .join("picotls-src")
             .join("include");
+        if has_picotls_header(&candidate) {
+            return Some(candidate);
+        }
+        let candidate = root.join("vendor").join("picotls").join("include");
         if has_picotls_header(&candidate) {
             return Some(candidate);
         }
@@ -250,24 +264,37 @@ fn has_picotls_header(dir: &Path) -> bool {
     dir.join("picotls.h").exists()
 }
 
+fn windows_stage_candidates(dir: &Path) -> [PathBuf; 2] {
+    [
+        dir.join("windows").join("x64").join("Release"),
+        dir.join("x64").join("Release"),
+    ]
+}
+
 fn has_picoquic_libs(dir: &Path) -> bool {
     resolve_picoquic_libs(dir).is_some()
 }
 
 fn resolve_picoquic_libs_single_dir(dir: &Path) -> Option<Vec<&'static str>> {
-    const REQUIRED: [(&str, &str); 4] = [
-        ("picoquic_core", "picoquic-core"),
-        ("picotls_core", "picotls-core"),
-        ("picotls_openssl", "picotls-openssl"),
-        ("picotls_minicrypto", "picotls-minicrypto"),
+    const REQUIRED: [(&[&str], &[&str]); 4] = [
+        (
+            &["picoquic_core", "picoquic-core", "picoquic"],
+            &["a", "lib"],
+        ),
+        (&["picotls_core", "picotls-core"], &["a", "lib"]),
+        (&["picotls_openssl", "picotls-openssl"], &["a", "lib"]),
+        (&["picotls_minicrypto", "picotls-minicrypto"], &["a", "lib"]),
     ];
     let mut libs = Vec::with_capacity(REQUIRED.len() + 1);
-    for (underscored, hyphenated) in REQUIRED {
-        libs.push(find_lib_variant(dir, underscored, hyphenated)?);
+    for (names, extensions) in REQUIRED {
+        libs.push(find_lib_variant(dir, names, extensions)?);
     }
-    if let Some(fusion) = find_lib_variant(dir, "picotls_fusion", "picotls-fusion") {
+    if let Some(fusion) =
+        find_lib_variant(dir, &["picotls_fusion", "picotls-fusion"], &["a", "lib"])
+    {
         libs.insert(3, fusion);
     }
+    append_picotls_minicrypto_support_libs(dir, &mut libs);
     Some(libs)
 }
 
@@ -275,27 +302,70 @@ fn resolve_picoquic_libs_split(
     picoquic_dir: &Path,
     picotls_dir: &Path,
 ) -> Option<Vec<&'static str>> {
-    let picoquic_core = find_lib_variant(picoquic_dir, "picoquic_core", "picoquic-core")?;
-    let picotls_core = find_lib_variant(picotls_dir, "picotls_core", "picotls-core")?;
-    let picotls_minicrypto =
-        find_lib_variant(picotls_dir, "picotls_minicrypto", "picotls-minicrypto")?;
-    let picotls_openssl = find_lib_variant(picotls_dir, "picotls_openssl", "picotls-openssl")?;
+    let picoquic_core = find_lib_variant(
+        picoquic_dir,
+        &["picoquic_core", "picoquic-core", "picoquic"],
+        &["a", "lib"],
+    )?;
+    let picotls_core = find_lib_variant(
+        picotls_dir,
+        &["picotls_core", "picotls-core"],
+        &["a", "lib"],
+    )?;
+    let picotls_minicrypto = find_lib_variant(
+        picotls_dir,
+        &["picotls_minicrypto", "picotls-minicrypto"],
+        &["a", "lib"],
+    )?;
+    let picotls_openssl = find_lib_variant(
+        picotls_dir,
+        &["picotls_openssl", "picotls-openssl"],
+        &["a", "lib"],
+    )?;
     let mut libs = vec![picoquic_core, picotls_core, picotls_openssl];
-    if let Some(fusion) = find_lib_variant(picotls_dir, "picotls_fusion", "picotls-fusion") {
+    if let Some(fusion) = find_lib_variant(
+        picotls_dir,
+        &["picotls_fusion", "picotls-fusion"],
+        &["a", "lib"],
+    ) {
         libs.push(fusion);
     }
     libs.push(picotls_minicrypto);
+    append_picotls_minicrypto_support_libs(picotls_dir, &mut libs);
     Some(libs)
 }
 
-fn find_lib_variant<'a>(dir: &Path, underscored: &'a str, hyphenated: &'a str) -> Option<&'a str> {
-    let underscored_path = dir.join(format!("lib{}.a", underscored));
-    if underscored_path.exists() {
-        return Some(underscored);
+fn append_picotls_minicrypto_support_libs(dir: &Path, libs: &mut Vec<&'static str>) {
+    if let (Some(cifra), Some(microecc)) = (
+        find_lib_variant(dir, &["cifra"], &["lib"]),
+        find_lib_variant(dir, &["microecc"], &["lib"]),
+    ) {
+        libs.push(cifra);
+        libs.push(microecc);
+        return;
     }
-    let hyphen_path = dir.join(format!("lib{}.a", hyphenated));
-    if hyphen_path.exists() {
-        return Some(hyphenated);
+
+    if let Some(deps) = find_lib_variant(
+        dir,
+        &["picotls_minicrypto_deps", "picotls-minicrypto-deps"],
+        &["a", "lib"],
+    ) {
+        libs.push(deps);
+    }
+}
+
+fn find_lib_variant<'a>(dir: &Path, names: &[&'a str], extensions: &[&str]) -> Option<&'a str> {
+    for name in names {
+        for extension in extensions {
+            let path = match *extension {
+                "a" => dir.join(format!("lib{}.a", name)),
+                "lib" => dir.join(format!("{}.lib", name)),
+                _ => continue,
+            };
+            if path.exists() {
+                return Some(name);
+            }
+        }
     }
     None
 }

--- a/crates/slipstream-ffi/build/picoquic.rs
+++ b/crates/slipstream-ffi/build/picoquic.rs
@@ -28,24 +28,7 @@ pub(crate) fn build_picoquic(
         .map(PathBuf::from)
         .unwrap_or_else(|| root.join(".picoquic-build"));
 
-    let mut command = if cfg!(windows) {
-        // On Windows, find Git Bash explicitly to avoid WSL bash.exe from System32
-        let git_bash_paths = [
-            PathBuf::from(r"C:\Program Files\Git\bin\bash.exe"),
-            PathBuf::from(r"C:\Program Files\Git\usr\bin\bash.exe"),
-        ];
-
-        let bash_exe = git_bash_paths
-            .iter()
-            .find(|path| path.exists())
-            .ok_or("Git Bash not found. Please install Git for Windows.")?;
-
-        let mut cmd = Command::new(bash_exe);
-        cmd.arg(&script);
-        cmd
-    } else {
-        Command::new(script)
-    };
+    let mut command = Command::new(script);
     command
         .env("PICOQUIC_DIR", picoquic_dir)
         .env("PICOQUIC_BUILD_DIR", build_dir)

--- a/crates/slipstream-ffi/build/picoquic.rs
+++ b/crates/slipstream-ffi/build/picoquic.rs
@@ -94,7 +94,7 @@ pub(crate) fn locate_picoquic_include_dir() -> Option<PathBuf> {
     None
 }
 
-pub(crate) fn locate_picoquic_lib_dir() -> Option<PathBuf> {
+pub(crate) fn locate_picoquic_lib_dir(is_windows: bool) -> Option<PathBuf> {
     if let Ok(dir) = env::var("PICOQUIC_LIB_DIR") {
         let candidate = PathBuf::from(dir);
         if has_picoquic_libs(&candidate) {
@@ -104,9 +104,11 @@ pub(crate) fn locate_picoquic_lib_dir() -> Option<PathBuf> {
 
     if let Ok(dir) = env::var("PICOQUIC_BUILD_DIR") {
         let build_dir = PathBuf::from(&dir);
-        for candidate in windows_stage_candidates(&build_dir) {
-            if has_picoquic_libs(&candidate) {
-                return Some(candidate);
+        if is_windows {
+            for candidate in windows_stage_candidates(&build_dir) {
+                if has_picoquic_libs(&candidate) {
+                    return Some(candidate);
+                }
             }
         }
         if has_picoquic_libs(&build_dir) {
@@ -120,9 +122,11 @@ pub(crate) fn locate_picoquic_lib_dir() -> Option<PathBuf> {
 
     if let Some(root) = locate_repo_root() {
         let build_dir = root.join(".picoquic-build");
-        for candidate in windows_stage_candidates(&build_dir) {
-            if has_picoquic_libs(&candidate) {
-                return Some(candidate);
+        if is_windows {
+            for candidate in windows_stage_candidates(&build_dir) {
+                if has_picoquic_libs(&candidate) {
+                    return Some(candidate);
+                }
             }
         }
         if has_picoquic_libs(&build_dir) {

--- a/crates/slipstream-ffi/cc/picotls_layout.c
+++ b/crates/slipstream-ffi/cc/picotls_layout.c
@@ -1,7 +1,10 @@
 #include <stddef.h>
 #include "picotls.h"
 
-#define LAYOUT_ASSERT_EQ(a, b) _Static_assert((a) == (b), "picotls layout mismatch")
+#define LAYOUT_ASSERT_JOIN_(a, b) a##b
+#define LAYOUT_ASSERT_JOIN(a, b) LAYOUT_ASSERT_JOIN_(a, b)
+#define LAYOUT_ASSERT_EQ(a, b) \
+    typedef char LAYOUT_ASSERT_JOIN(layout_assertion_, __LINE__)[((a) == (b)) ? 1 : -1]
 
 LAYOUT_ASSERT_EQ(offsetof(ptls_iovec_t, base), 0);
 LAYOUT_ASSERT_EQ(offsetof(ptls_iovec_t, len), sizeof(void *));

--- a/crates/slipstream-ffi/src/lib.rs
+++ b/crates/slipstream-ffi/src/lib.rs
@@ -39,5 +39,6 @@ pub struct ClientConfig<'a> {
 pub use runtime::{
     abort_stream_bidi, configure_quic, configure_quic_with_custom, sockaddr_storage_to_socket_addr,
     socket_addr_to_storage, take_crypto_errors, take_stateless_packet_for_cid,
-    write_stream_or_reset, QuicGuard, SLIPSTREAM_FILE_CANCEL_ERROR, SLIPSTREAM_INTERNAL_ERROR,
+    write_stream_or_reset, QuicGuard, SockaddrStorage, SLIPSTREAM_FILE_CANCEL_ERROR,
+    SLIPSTREAM_INTERNAL_ERROR,
 };

--- a/crates/slipstream-ffi/src/lib.rs
+++ b/crates/slipstream-ffi/src/lib.rs
@@ -6,8 +6,7 @@ use slipstream_core::HostPort;
 pub mod picoquic;
 pub mod runtime;
 
-pub use picoquic::get_pacing_rate;
-pub use picoquic::get_rtt;
+pub use picoquic::{get_pacing_rate, get_rtt, SockaddrStorage};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
@@ -39,6 +38,5 @@ pub struct ClientConfig<'a> {
 pub use runtime::{
     abort_stream_bidi, configure_quic, configure_quic_with_custom, sockaddr_storage_to_socket_addr,
     socket_addr_to_storage, take_crypto_errors, take_stateless_packet_for_cid,
-    write_stream_or_reset, QuicGuard, SockaddrStorage, SLIPSTREAM_FILE_CANCEL_ERROR,
-    SLIPSTREAM_INTERNAL_ERROR,
+    write_stream_or_reset, QuicGuard, SLIPSTREAM_FILE_CANCEL_ERROR, SLIPSTREAM_INTERNAL_ERROR,
 };

--- a/crates/slipstream-ffi/src/picoquic.rs
+++ b/crates/slipstream-ffi/src/picoquic.rs
@@ -1,9 +1,9 @@
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
-#[cfg(not(windows))]
-use libc::{c_char, c_int, c_uint, c_void, size_t, sockaddr, sockaddr_storage};
 #[cfg(windows)]
 use libc::{c_char, c_int, c_uint, c_void, size_t, sockaddr};
+#[cfg(not(windows))]
+use libc::{c_char, c_int, c_uint, c_void, size_t, sockaddr, sockaddr_storage};
 #[cfg(windows)]
 use winapi::shared::ws2def::SOCKADDR_STORAGE as sockaddr_storage;
 

--- a/crates/slipstream-ffi/src/picoquic.rs
+++ b/crates/slipstream-ffi/src/picoquic.rs
@@ -1,6 +1,11 @@
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
+#[cfg(not(windows))]
 use libc::{c_char, c_int, c_uint, c_void, size_t, sockaddr, sockaddr_storage};
+#[cfg(windows)]
+use libc::{c_char, c_int, c_uint, c_void, size_t, sockaddr};
+#[cfg(windows)]
+use winapi::shared::ws2def::SOCKADDR_STORAGE as sockaddr_storage;
 
 pub const PICOQUIC_CONNECTION_ID_MAX_SIZE: usize = 20;
 pub const PICOQUIC_MAX_PACKET_SIZE: usize = 1536;

--- a/crates/slipstream-ffi/src/picoquic.rs
+++ b/crates/slipstream-ffi/src/picoquic.rs
@@ -1,11 +1,11 @@
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
-#[cfg(windows)]
 use libc::{c_char, c_int, c_uint, c_void, size_t, sockaddr};
+
 #[cfg(not(windows))]
-use libc::{c_char, c_int, c_uint, c_void, size_t, sockaddr, sockaddr_storage};
+pub type SockaddrStorage = libc::sockaddr_storage;
 #[cfg(windows)]
-use winapi::shared::ws2def::SOCKADDR_STORAGE as sockaddr_storage;
+pub type SockaddrStorage = winapi::shared::ws2def::SOCKADDR_STORAGE;
 
 pub const PICOQUIC_CONNECTION_ID_MAX_SIZE: usize = 20;
 pub const PICOQUIC_MAX_PACKET_SIZE: usize = 1536;
@@ -350,8 +350,8 @@ extern "C" {
         send_buffer: *mut u8,
         send_buffer_max: size_t,
         send_length: *mut size_t,
-        p_addr_to: *mut sockaddr_storage,
-        p_addr_from: *mut sockaddr_storage,
+        p_addr_to: *mut SockaddrStorage,
+        p_addr_from: *mut SockaddrStorage,
         if_index: *mut c_int,
         log_cid: *mut picoquic_connection_id_t,
         p_last_cnx: *mut *mut picoquic_cnx_t,
@@ -365,8 +365,8 @@ extern "C" {
         send_buffer: *mut u8,
         send_buffer_max: size_t,
         send_length: *mut size_t,
-        p_addr_to: *mut sockaddr_storage,
-        p_addr_from: *mut sockaddr_storage,
+        p_addr_to: *mut SockaddrStorage,
+        p_addr_from: *mut SockaddrStorage,
         if_index: *mut c_int,
         send_msg_size: *mut size_t,
     ) -> c_int;
@@ -442,7 +442,7 @@ extern "C" {
         cnx: *mut picoquic_cnx_t,
         unique_path_id: u64,
         local: c_int,
-        addr: *mut sockaddr_storage,
+        addr: *mut SockaddrStorage,
     ) -> c_int;
 }
 

--- a/crates/slipstream-ffi/src/runtime.rs
+++ b/crates/slipstream-ffi/src/runtime.rs
@@ -318,7 +318,7 @@ pub fn sockaddr_storage_to_socket_addr(storage: &sockaddr_storage) -> Result<Soc
         AF_INET => {
             let addr_in: &SOCKADDR_IN =
                 unsafe { &*(storage as *const _ as *const SOCKADDR_IN) };
-            let ip = Ipv4Addr::from(addr_in.sin_addr.S_un.S_addr());
+            let ip = Ipv4Addr::from(unsafe { *addr_in.sin_addr.S_un.S_addr() });
             let port = u16::from_be(addr_in.sin_port);
             Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
         }

--- a/crates/slipstream-ffi/src/runtime.rs
+++ b/crates/slipstream-ffi/src/runtime.rs
@@ -287,7 +287,7 @@ pub fn socket_addr_to_storage(addr: SocketAddr) -> sockaddr_storage {
                 let sockaddr_ptr = &mut storage as *mut _ as *mut SOCKADDR_IN;
                 (*sockaddr_ptr).sin_family = AF_INET as u16;
                 (*sockaddr_ptr).sin_port = addr.port().to_be();
-                *(*sockaddr_ptr).sin_addr.S_un.S_addr_mut() = u32::from_ne_bytes(addr.ip().octets());
+                *(*sockaddr_ptr).sin_addr.S_un.S_addr_mut() = u32::from_be_bytes(addr.ip().octets());
             }
             storage
         }
@@ -318,7 +318,7 @@ pub fn sockaddr_storage_to_socket_addr(storage: &sockaddr_storage) -> Result<Soc
         AF_INET => {
             let addr_in: &SOCKADDR_IN =
                 unsafe { &*(storage as *const _ as *const SOCKADDR_IN) };
-            let ip = Ipv4Addr::from(unsafe { addr_in.sin_addr.S_un.S_addr().to_ne_bytes() });
+            let ip = Ipv4Addr::from(addr_in.sin_addr.S_un.S_addr());
             let port = u16::from_be(addr_in.sin_port);
             Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
         }

--- a/crates/slipstream-ffi/src/runtime.rs
+++ b/crates/slipstream-ffi/src/runtime.rs
@@ -8,7 +8,14 @@ use crate::picoquic::{
     picoquic_set_preemptive_repeat_policy, picoquic_set_stream_data_consumption_mode,
     picoquic_stop_sending, slipstream_take_stateless_packet_for_cid, PICOQUIC_MAX_PACKET_SIZE,
 };
+#[cfg(not(windows))]
 use libc::{c_char, c_int, c_ulong, size_t, sockaddr_storage};
+#[cfg(windows)]
+use winapi::shared::ws2def::{SOCKADDR_STORAGE as sockaddr_storage, SOCKADDR_IN, AF_INET, AF_INET6};
+#[cfg(windows)]
+use winapi::shared::ws2ipdef::SOCKADDR_IN6_LH;
+#[cfg(windows)]
+use libc::{c_char, c_int, c_ulong, size_t};
 use slipstream_core::tcp::stream_write_buffer_bytes;
 use std::ffi::CStr;
 use std::io::Write;
@@ -124,6 +131,13 @@ pub fn take_crypto_errors() -> Vec<String> {
     errors
 }
 
+// Re-export sockaddr_storage for use by other crates
+#[cfg(not(windows))]
+pub use libc::sockaddr_storage as SockaddrStorage;
+#[cfg(windows)]
+pub use winapi::shared::ws2def::SOCKADDR_STORAGE as SockaddrStorage;
+
+#[cfg(not(windows))]
 pub fn socket_addr_to_storage(addr: SocketAddr) -> sockaddr_storage {
     match addr {
         SocketAddr::V4(addr) => {
@@ -180,6 +194,7 @@ pub fn socket_addr_to_storage(addr: SocketAddr) -> sockaddr_storage {
     }
 }
 
+#[cfg(not(windows))]
 pub fn sockaddr_storage_to_socket_addr(storage: &sockaddr_storage) -> Result<SocketAddr, String> {
     match storage.ss_family as libc::c_int {
         libc::AF_INET => {
@@ -261,4 +276,70 @@ pub unsafe fn write_stream_or_reset(
 pub unsafe fn abort_stream_bidi(cnx: *mut picoquic_cnx_t, stream_id: u64, app_error: u64) {
     let _ = picoquic_stop_sending(cnx, stream_id, app_error);
     let _ = picoquic_reset_stream(cnx, stream_id, app_error);
+}
+
+#[cfg(windows)]
+pub fn socket_addr_to_storage(addr: SocketAddr) -> sockaddr_storage {
+    match addr {
+        SocketAddr::V4(addr) => {
+            let mut storage: sockaddr_storage = unsafe { std::mem::zeroed() };
+            unsafe {
+                let sockaddr_ptr = &mut storage as *mut _ as *mut SOCKADDR_IN;
+                (*sockaddr_ptr).sin_family = AF_INET as u16;
+                (*sockaddr_ptr).sin_port = addr.port().to_be();
+                *(*sockaddr_ptr).sin_addr.S_un.S_addr_mut() = u32::from_ne_bytes(addr.ip().octets());
+            }
+            storage
+        }
+        SocketAddr::V6(addr) => {
+            let mut storage: sockaddr_storage = unsafe { std::mem::zeroed() };
+            unsafe {
+                let sockaddr_ptr = &mut storage as *mut _ as *mut SOCKADDR_IN6_LH;
+                (*sockaddr_ptr).sin6_family = AF_INET6 as u16;
+                (*sockaddr_ptr).sin6_port = addr.port().to_be();
+                (*sockaddr_ptr).sin6_flowinfo = addr.flowinfo();
+                // Copy IPv6 address bytes directly using raw pointer
+                let addr_bytes = addr.ip().octets();
+                let dest_ptr = &mut (*sockaddr_ptr).sin6_addr as *mut _ as *mut u8;
+                std::ptr::copy_nonoverlapping(addr_bytes.as_ptr(), dest_ptr, 16);
+                // Set scope_id via the union
+                let scope_ptr = &mut (*sockaddr_ptr).u as *mut _ as *mut u32;
+                *scope_ptr = addr.scope_id();
+            }
+            storage
+        }
+    }
+}
+
+#[cfg(windows)]
+pub fn sockaddr_storage_to_socket_addr(storage: &sockaddr_storage) -> Result<SocketAddr, String> {
+    let family = storage.ss_family as i32;
+    match family {
+        AF_INET => {
+            let addr_in: &SOCKADDR_IN =
+                unsafe { &*(storage as *const _ as *const SOCKADDR_IN) };
+            let ip = Ipv4Addr::from(unsafe { addr_in.sin_addr.S_un.S_addr().to_ne_bytes() });
+            let port = u16::from_be(addr_in.sin_port);
+            Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
+        }
+        AF_INET6 => {
+            let addr_in6: &SOCKADDR_IN6_LH =
+                unsafe { &*(storage as *const _ as *const SOCKADDR_IN6_LH) };
+            // Read IPv6 address bytes directly using raw pointer
+            let src_ptr = &addr_in6.sin6_addr as *const _ as *const u8;
+            let mut ip_bytes: [u8; 16] = [0; 16];
+            unsafe { std::ptr::copy_nonoverlapping(src_ptr, ip_bytes.as_mut_ptr(), 16) };
+            let ip = Ipv6Addr::from(ip_bytes);
+            let port = u16::from_be(addr_in6.sin6_port);
+            // Read scope_id via the union
+            let scope_id = unsafe { *(&addr_in6.u as *const _ as *const u32) };
+            Ok(SocketAddr::V6(SocketAddrV6::new(
+                ip,
+                port,
+                addr_in6.sin6_flowinfo,
+                scope_id,
+            )))
+        }
+        _ => Err("Unsupported sockaddr family".to_string()),
+    }
 }

--- a/crates/slipstream-ffi/src/runtime.rs
+++ b/crates/slipstream-ffi/src/runtime.rs
@@ -6,20 +6,19 @@ use crate::picoquic::{
     picoquic_set_default_priority, picoquic_set_initial_send_mtu,
     picoquic_set_key_log_file_from_env, picoquic_set_max_data_control, picoquic_set_mtu_max,
     picoquic_set_preemptive_repeat_policy, picoquic_set_stream_data_consumption_mode,
-    picoquic_stop_sending, slipstream_take_stateless_packet_for_cid, PICOQUIC_MAX_PACKET_SIZE,
+    picoquic_stop_sending, slipstream_take_stateless_packet_for_cid, SockaddrStorage,
+    PICOQUIC_MAX_PACKET_SIZE,
 };
 #[cfg(windows)]
 use libc::{c_char, c_int, c_ulong, size_t};
 #[cfg(not(windows))]
-use libc::{c_char, c_int, c_ulong, size_t, sockaddr_storage};
+use libc::{c_char, c_int, c_ulong, size_t};
 use slipstream_core::tcp::stream_write_buffer_bytes;
 use std::ffi::CStr;
 use std::io::Write;
 use std::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, SocketAddrV4, SocketAddrV6, TcpStream};
 #[cfg(windows)]
-use winapi::shared::ws2def::{
-    AF_INET, AF_INET6, SOCKADDR_IN, SOCKADDR_STORAGE as sockaddr_storage,
-};
+use winapi::shared::ws2def::{AF_INET, AF_INET6, SOCKADDR_IN};
 #[cfg(windows)]
 use winapi::shared::ws2ipdef::SOCKADDR_IN6_LH;
 
@@ -133,18 +132,12 @@ pub fn take_crypto_errors() -> Vec<String> {
     errors
 }
 
-// Re-export sockaddr_storage for use by other crates
 #[cfg(not(windows))]
-pub use libc::sockaddr_storage as SockaddrStorage;
-#[cfg(windows)]
-pub use winapi::shared::ws2def::SOCKADDR_STORAGE as SockaddrStorage;
-
-#[cfg(not(windows))]
-pub fn socket_addr_to_storage(addr: SocketAddr) -> sockaddr_storage {
+pub fn socket_addr_to_storage(addr: SocketAddr) -> SockaddrStorage {
     match addr {
         SocketAddr::V4(addr) => {
             // SAFETY: sockaddr_storage is plain-old-data; zeroing is valid.
-            let mut storage: sockaddr_storage = unsafe { std::mem::zeroed() };
+            let mut storage: SockaddrStorage = unsafe { std::mem::zeroed() };
             let sockaddr = libc::sockaddr_in {
                 #[cfg(any(
                     target_vendor = "apple",
@@ -157,7 +150,7 @@ pub fn socket_addr_to_storage(addr: SocketAddr) -> sockaddr_storage {
                 sin_family: libc::AF_INET as libc::sa_family_t,
                 sin_port: addr.port().to_be(),
                 sin_addr: libc::in_addr {
-                    s_addr: u32::from_be_bytes(addr.ip().octets()),
+                    s_addr: u32::from_ne_bytes(addr.ip().octets()),
                 },
                 sin_zero: [0; 8],
             };
@@ -169,7 +162,7 @@ pub fn socket_addr_to_storage(addr: SocketAddr) -> sockaddr_storage {
         }
         SocketAddr::V6(addr) => {
             // SAFETY: sockaddr_storage is plain-old-data; zeroing is valid.
-            let mut storage: sockaddr_storage = unsafe { std::mem::zeroed() };
+            let mut storage: SockaddrStorage = unsafe { std::mem::zeroed() };
             let sockaddr = libc::sockaddr_in6 {
                 #[cfg(any(
                     target_vendor = "apple",
@@ -197,13 +190,13 @@ pub fn socket_addr_to_storage(addr: SocketAddr) -> sockaddr_storage {
 }
 
 #[cfg(not(windows))]
-pub fn sockaddr_storage_to_socket_addr(storage: &sockaddr_storage) -> Result<SocketAddr, String> {
+pub fn sockaddr_storage_to_socket_addr(storage: &SockaddrStorage) -> Result<SocketAddr, String> {
     match storage.ss_family as libc::c_int {
         libc::AF_INET => {
             // SAFETY: ss_family identifies an IPv4 sockaddr layout.
             let addr_in: &libc::sockaddr_in =
                 unsafe { &*(storage as *const _ as *const libc::sockaddr_in) };
-            let ip = Ipv4Addr::from(addr_in.sin_addr.s_addr);
+            let ip = Ipv4Addr::from(addr_in.sin_addr.s_addr.to_ne_bytes());
             let port = u16::from_be(addr_in.sin_port);
             Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
         }
@@ -281,24 +274,24 @@ pub unsafe fn abort_stream_bidi(cnx: *mut picoquic_cnx_t, stream_id: u64, app_er
 }
 
 #[cfg(windows)]
-pub fn socket_addr_to_storage(addr: SocketAddr) -> sockaddr_storage {
+pub fn socket_addr_to_storage(addr: SocketAddr) -> SockaddrStorage {
     match addr {
         SocketAddr::V4(addr) => {
             // SAFETY: sockaddr_storage is plain-old-data; zeroing is valid.
-            let mut storage: sockaddr_storage = unsafe { std::mem::zeroed() };
+            let mut storage: SockaddrStorage = unsafe { std::mem::zeroed() };
             unsafe {
                 // SAFETY: storage is properly aligned and large enough for SOCKADDR_IN.
                 let sockaddr_ptr = &mut storage as *mut _ as *mut SOCKADDR_IN;
                 (*sockaddr_ptr).sin_family = AF_INET as u16;
                 (*sockaddr_ptr).sin_port = addr.port().to_be();
                 *(*sockaddr_ptr).sin_addr.S_un.S_addr_mut() =
-                    u32::from_be_bytes(addr.ip().octets());
+                    u32::from_ne_bytes(addr.ip().octets());
             }
             storage
         }
         SocketAddr::V6(addr) => {
             // SAFETY: sockaddr_storage is plain-old-data; zeroing is valid.
-            let mut storage: sockaddr_storage = unsafe { std::mem::zeroed() };
+            let mut storage: SockaddrStorage = unsafe { std::mem::zeroed() };
             unsafe {
                 // SAFETY: storage is properly aligned and large enough for SOCKADDR_IN6_LH.
                 let sockaddr_ptr = &mut storage as *mut _ as *mut SOCKADDR_IN6_LH;
@@ -321,14 +314,14 @@ pub fn socket_addr_to_storage(addr: SocketAddr) -> sockaddr_storage {
 }
 
 #[cfg(windows)]
-pub fn sockaddr_storage_to_socket_addr(storage: &sockaddr_storage) -> Result<SocketAddr, String> {
+pub fn sockaddr_storage_to_socket_addr(storage: &SockaddrStorage) -> Result<SocketAddr, String> {
     let family = storage.ss_family as i32;
     match family {
         AF_INET => {
             // SAFETY: ss_family identifies an IPv4 sockaddr layout.
             let addr_in: &SOCKADDR_IN = unsafe { &*(storage as *const _ as *const SOCKADDR_IN) };
             // SAFETY: S_un union contains S_addr (u32) for IPv4 addresses on Windows.
-            let ip = Ipv4Addr::from(unsafe { *addr_in.sin_addr.S_un.S_addr() });
+            let ip = Ipv4Addr::from(unsafe { *addr_in.sin_addr.S_un.S_addr() }.to_ne_bytes());
             let port = u16::from_be(addr_in.sin_port);
             Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
         }
@@ -354,5 +347,55 @@ pub fn sockaddr_storage_to_socket_addr(storage: &sockaddr_storage) -> Result<Soc
             )))
         }
         _ => Err("Unsupported sockaddr family".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socket_addr_storage_round_trips_ipv4() {
+        let addr: SocketAddr = "203.0.113.9:4433".parse().unwrap();
+        let storage = socket_addr_to_storage(addr);
+
+        assert_eq!(sockaddr_storage_to_socket_addr(&storage).unwrap(), addr);
+    }
+
+    #[test]
+    fn socket_addr_storage_preserves_ipv4_network_octets() {
+        let addr: SocketAddr = "203.0.113.9:4433".parse().unwrap();
+        let storage = socket_addr_to_storage(addr);
+
+        #[cfg(not(windows))]
+        {
+            // SAFETY: socket_addr_to_storage wrote an IPv4 sockaddr.
+            let addr_in: &libc::sockaddr_in =
+                unsafe { &*(&storage as *const _ as *const libc::sockaddr_in) };
+            assert_eq!(addr_in.sin_addr.s_addr.to_ne_bytes(), [203, 0, 113, 9]);
+        }
+
+        #[cfg(windows)]
+        {
+            // SAFETY: socket_addr_to_storage wrote an IPv4 sockaddr.
+            let addr_in: &SOCKADDR_IN = unsafe { &*(&storage as *const _ as *const SOCKADDR_IN) };
+            assert_eq!(
+                unsafe { *addr_in.sin_addr.S_un.S_addr() }.to_ne_bytes(),
+                [203, 0, 113, 9]
+            );
+        }
+    }
+
+    #[test]
+    fn socket_addr_storage_round_trips_ipv6() {
+        let addr = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::new(0x2001, 0xdb8, 1, 2, 3, 4, 5, 6),
+            4434,
+            7,
+            8,
+        ));
+        let storage = socket_addr_to_storage(addr);
+
+        assert_eq!(sockaddr_storage_to_socket_addr(&storage).unwrap(), addr);
     }
 }

--- a/crates/slipstream-ffi/src/runtime.rs
+++ b/crates/slipstream-ffi/src/runtime.rs
@@ -9,9 +9,6 @@ use crate::picoquic::{
     picoquic_stop_sending, slipstream_take_stateless_packet_for_cid, SockaddrStorage,
     PICOQUIC_MAX_PACKET_SIZE,
 };
-#[cfg(windows)]
-use libc::{c_char, c_int, c_ulong, size_t};
-#[cfg(not(windows))]
 use libc::{c_char, c_int, c_ulong, size_t};
 use slipstream_core::tcp::stream_write_buffer_bytes;
 use std::ffi::CStr;

--- a/crates/slipstream-server/src/config.rs
+++ b/crates/slipstream-server/src/config.rs
@@ -267,12 +267,12 @@ fn write_pem_file(path: &Path, bytes: &[u8], mode: u32) -> io::Result<()> {
     Ok(())
 }
 
-fn open_new_with_mode(path: &Path, mode: u32) -> io::Result<File> {
+fn open_new_with_mode(path: &Path, _mode: u32) -> io::Result<File> {
     let mut options = OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]
     {
-        options.mode(mode);
+        options.mode(_mode);
     }
     options.open(path)
 }

--- a/crates/slipstream-server/src/config.rs
+++ b/crates/slipstream-server/src/config.rs
@@ -267,13 +267,18 @@ fn write_pem_file(path: &Path, bytes: &[u8], mode: u32) -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn open_new_with_mode(path: &Path, mode: u32) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    options.mode(mode);
+    options.open(path)
+}
+
+#[cfg(not(unix))]
 fn open_new_with_mode(path: &Path, _mode: u32) -> io::Result<File> {
     let mut options = OpenOptions::new();
     options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        options.mode(_mode);
-    }
     options.open(path)
 }
 

--- a/crates/slipstream-server/src/server.rs
+++ b/crates/slipstream-server/src/server.rs
@@ -379,8 +379,8 @@ pub async fn run_server(config: &ServerConfig) -> Result<i32, ServerError> {
 
         for slot in slots.iter_mut() {
             let mut send_length = 0usize;
-            let mut addr_to: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-            let mut addr_from: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+            let mut addr_to: slipstream_ffi::SockaddrStorage = unsafe { std::mem::zeroed() };
+            let mut addr_from: slipstream_ffi::SockaddrStorage = unsafe { std::mem::zeroed() };
             let mut if_index: libc::c_int = 0;
 
             if slot.payload_override.is_none() && slot.rcode.is_none() && !slot.cnx.is_null() {

--- a/crates/slipstream-server/src/udp_fallback.rs
+++ b/crates/slipstream-server/src/udp_fallback.rs
@@ -29,7 +29,7 @@ pub(crate) struct PacketContext<'a> {
     pub(crate) domains: &'a [&'a str],
     pub(crate) quic: *mut picoquic_quic_t,
     pub(crate) current_time: u64,
-    pub(crate) local_addr_storage: &'a libc::sockaddr_storage,
+    pub(crate) local_addr_storage: &'a slipstream_ffi::SockaddrStorage,
 }
 
 /// Tracks per-peer routing for UDP fallback based on DNS decoding outcomes.
@@ -56,11 +56,25 @@ mod session;
 
 pub(crate) use decode::handle_packet;
 
+#[cfg(not(windows))]
 fn dummy_sockaddr_storage() -> libc::sockaddr_storage {
     socket_addr_to_storage(SocketAddr::new(
         IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
         12345,
     ))
+}
+
+#[cfg(windows)]
+fn dummy_sockaddr_storage() -> slipstream_ffi::SockaddrStorage {
+    use std::net::{Ipv6Addr, SocketAddrV6};
+    slipstream_ffi::socket_addr_to_storage(
+        std::net::SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
+            12345,
+            0,
+            0,
+        ))
+    )
 }
 
 #[cfg(test)]

--- a/crates/slipstream-server/src/udp_fallback.rs
+++ b/crates/slipstream-server/src/udp_fallback.rs
@@ -67,14 +67,12 @@ fn dummy_sockaddr_storage() -> libc::sockaddr_storage {
 #[cfg(windows)]
 fn dummy_sockaddr_storage() -> slipstream_ffi::SockaddrStorage {
     use std::net::{Ipv6Addr, SocketAddrV6};
-    slipstream_ffi::socket_addr_to_storage(
-        std::net::SocketAddr::V6(SocketAddrV6::new(
-            Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
-            12345,
-            0,
-            0,
-        ))
-    )
+    slipstream_ffi::socket_addr_to_storage(std::net::SocketAddr::V6(SocketAddrV6::new(
+        Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
+        12345,
+        0,
+        0,
+    )))
 }
 
 #[cfg(test)]

--- a/crates/slipstream-server/src/udp_fallback.rs
+++ b/crates/slipstream-server/src/udp_fallback.rs
@@ -1,7 +1,4 @@
-use slipstream_ffi::picoquic::{
-    picoquic_cnx_t, picoquic_incoming_packet_ex, picoquic_quic_t, slipstream_disable_ack_delay,
-};
-#[cfg(not(windows))]
+use slipstream_ffi::picoquic::picoquic_quic_t;
 use slipstream_ffi::socket_addr_to_storage;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};

--- a/crates/slipstream-server/src/udp_fallback.rs
+++ b/crates/slipstream-server/src/udp_fallback.rs
@@ -1,4 +1,7 @@
-use slipstream_ffi::picoquic::picoquic_quic_t;
+use slipstream_ffi::picoquic::{
+    picoquic_cnx_t, picoquic_incoming_packet_ex, picoquic_quic_t, slipstream_disable_ack_delay,
+};
+#[cfg(not(windows))]
 use slipstream_ffi::socket_addr_to_storage;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};

--- a/crates/slipstream-server/src/udp_fallback/decode.rs
+++ b/crates/slipstream-server/src/udp_fallback/decode.rs
@@ -62,7 +62,7 @@ fn decode_slot(
     domains: &[&str],
     quic: *mut picoquic_quic_t,
     current_time: u64,
-    local_addr_storage: &libc::sockaddr_storage,
+    local_addr_storage: &slipstream_ffi::SockaddrStorage,
 ) -> Result<DecodeSlotOutcome, ServerError> {
     match decode_query_with_domains(packet, domains) {
         Ok(query) => {

--- a/docs/build.md
+++ b/docs/build.md
@@ -18,7 +18,7 @@ Initialize it before building:
 git submodule update --init --recursive
 ```
 
-## Default build (auto-build picoquic)
+## Default build (non-Windows hosts)
 
 The build script in crates/slipstream-ffi will auto-build picoquic if the
 headers and libs are missing. It uses vendor/picoquic and writes outputs to
@@ -35,7 +35,33 @@ You can disable auto-build with:
 PICOQUIC_AUTO_BUILD=0 cargo build -p slipstream-client -p slipstream-server
 ```
 
-## Manual picoquic build
+Windows targets are not supported from Linux hosts in this repo.
+
+## Windows target build
+
+Windows builds are only supported from a Windows host. The supported path is
+the repo helper below, which builds picotls and picoquic with the upstream
+Visual Studio projects and stages the resulting libraries into a layout that
+Cargo auto-detects:
+
+```
+pwsh -File ./scripts/build_picoquic_windows.ps1
+cargo build -p slipstream-client -p slipstream-server
+```
+
+By default the helper:
+
+- checks out picotls into `vendor/picotls/` as an untracked working tree
+- stages Windows libraries into `.picoquic-build/windows/x64/Release/`
+- lets `cargo build` auto-detect `vendor/picoquic/picoquic` and `vendor/picotls/include`
+
+If you need a custom layout, these environment variables are still supported:
+
+- `PICOQUIC_INCLUDE_DIR`: picoquic headers
+- `PICOQUIC_LIB_DIR`: directory containing `picoquic.lib` and picotls `.lib` files
+- `PICOTLS_INCLUDE_DIR`: picotls headers
+
+## Manual picoquic build (non-Windows hosts)
 
 If you prefer to build picoquic yourself, run:
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -39,10 +39,10 @@ Windows targets are not supported from Linux hosts in this repo.
 
 ## Windows target build
 
-Windows builds are only supported from a Windows host. The supported path is
-the repo helper below, which builds picotls and picoquic with the upstream
-Visual Studio projects and stages the resulting libraries into a layout that
-Cargo auto-detects:
+Windows builds are only supported from a Windows host targeting
+`x86_64-pc-windows-msvc`. The supported path is the repo helper below, which
+builds picotls and picoquic with the upstream Visual Studio projects and stages
+the resulting libraries into a layout that Cargo auto-detects:
 
 ```
 pwsh -File ./scripts/build_picoquic_windows.ps1
@@ -53,6 +53,7 @@ By default the helper:
 
 - checks out picotls into `vendor/picotls/` as an untracked working tree
 - stages Windows libraries into `.picoquic-build/windows/x64/Release/`
+- stages OpenSSL headers and import libraries into `.picoquic-build/windows/openssl/`
 - lets `cargo build` auto-detect `vendor/picoquic/picoquic` and `vendor/picotls/include`
 
 If you need a custom layout, these environment variables are still supported:

--- a/docs/build.md
+++ b/docs/build.md
@@ -46,7 +46,9 @@ upstream Visual Studio projects, stages static OpenSSL libraries from the runner
 image, and exports the Cargo environment through `GITHUB_ENV`.
 
 The uploaded Windows artifact is expected to contain only the two Slipstream
-executables plus checksums. CI rejects artifacts that depend on OpenSSL DLLs.
+executables plus checksums. CI rejects artifacts with non-platform DLL
+dependencies; Windows system DLLs, API-set DLLs, and the VC/UCRT runtime are
+allowed.
 
 ## Manual picoquic build (non-Windows hosts)
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -39,28 +39,14 @@ Windows targets are not supported from Linux hosts in this repo.
 
 ## Windows target build
 
-Windows builds are only supported from a Windows host targeting
-`x86_64-pc-windows-msvc`. The supported path is the repo helper below, which
-builds picotls and picoquic with the upstream Visual Studio projects and stages
-the resulting libraries into a layout that Cargo auto-detects:
+Windows binary builds are supported in GitHub Actions on the hosted
+`windows-latest` runner targeting `x86_64-pc-windows-msvc`. The workflow runs
+`scripts/build_picoquic_windows.ps1`, which builds picotls and picoquic with the
+upstream Visual Studio projects, stages static OpenSSL libraries from the runner
+image, and exports the Cargo environment through `GITHUB_ENV`.
 
-```
-pwsh -File ./scripts/build_picoquic_windows.ps1
-cargo build -p slipstream-client -p slipstream-server
-```
-
-By default the helper:
-
-- checks out picotls into `vendor/picotls/` as an untracked working tree
-- stages Windows libraries into `.picoquic-build/windows/x64/Release/`
-- stages OpenSSL headers and import libraries into `.picoquic-build/windows/openssl/`
-- lets `cargo build` auto-detect `vendor/picoquic/picoquic` and `vendor/picotls/include`
-
-If you need a custom layout, these environment variables are still supported:
-
-- `PICOQUIC_INCLUDE_DIR`: picoquic headers
-- `PICOQUIC_LIB_DIR`: directory containing `picoquic.lib` and picotls `.lib` files
-- `PICOTLS_INCLUDE_DIR`: picotls headers
+The uploaded Windows artifact is expected to contain only the two Slipstream
+executables plus checksums. CI rejects artifacts that depend on OpenSSL DLLs.
 
 ## Manual picoquic build (non-Windows hosts)
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -35,7 +35,8 @@ You can disable auto-build with:
 PICOQUIC_AUTO_BUILD=0 cargo build -p slipstream-client -p slipstream-server
 ```
 
-Windows targets are not supported from Linux hosts in this repo.
+For Windows targets, Cargo does not auto-build picoquic; provide explicit
+picoquic/picotls build directories or use the Windows helper below.
 
 ## Windows target build
 
@@ -44,6 +45,10 @@ Windows binary builds are supported in GitHub Actions on the hosted
 `scripts/build_picoquic_windows.ps1`, which builds picotls and picoquic with the
 upstream Visual Studio projects, stages static OpenSSL libraries from the runner
 image, and exports the Cargo environment through `GITHUB_ENV`.
+
+Other Windows build arrangements are not blocked when `PICOQUIC_INCLUDE_DIR`,
+`PICOQUIC_LIB_DIR`, and `PICOTLS_INCLUDE_DIR` point at compatible prebuilt
+artifacts, but CI only exercises `x86_64-pc-windows-msvc`.
 
 The uploaded Windows artifact is expected to contain only the two Slipstream
 executables plus checksums. CI rejects artifacts with non-platform DLL

--- a/docs/config.md
+++ b/docs/config.md
@@ -69,10 +69,10 @@ These affect the build script in crates/slipstream-ffi:
   picoquic headers directory (default: vendor/picoquic/picoquic).
 
 - PICOTLS_INCLUDE_DIR
-  picotls headers directory (default: .picoquic-build/_deps/picotls-src/include).
+  picotls headers directory (default: .picoquic-build/_deps/picotls-src/include on non-Windows, vendor/picotls/include for the Windows helper).
 
 - PICOQUIC_BUILD_DIR
-  picoquic build output (default: .picoquic-build).
+  picoquic build output (default: .picoquic-build; the Windows helper stages libs under .picoquic-build/windows/x64/Release by default).
 
 - PICOQUIC_LIB_DIR
   Directory containing picoquic and picotls libraries.

--- a/docs/config.md
+++ b/docs/config.md
@@ -72,7 +72,7 @@ These affect the build script in crates/slipstream-ffi:
   picotls headers directory (default: .picoquic-build/_deps/picotls-src/include on non-Windows, vendor/picotls/include for the Windows helper).
 
 - PICOQUIC_BUILD_DIR
-  picoquic build output (default: .picoquic-build; the Windows helper stages libs under .picoquic-build/windows/x64/Release by default).
+  picoquic build output (default: .picoquic-build; the Windows helper stages libs under .picoquic-build/windows/x64/Release and OpenSSL under .picoquic-build/windows/openssl by default).
 
 - PICOQUIC_LIB_DIR
   Directory containing picoquic and picotls libraries.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,6 +23,7 @@ contributors; "dev-only" scripts are internal or experimental.
 ## Public scripts
 
 - `scripts/build_picoquic.sh`: build picoquic for the Rust FFI layer.
+- `scripts/build_picoquic_windows.ps1`: build and stage picoquic/picotls for the supported Windows-hosted flow.
 - `scripts/gen_vectors.sh`: regenerate DNS vectors (requires the C repo).
 - `scripts/interop/run_rust_rust.sh`: Rust client/server interop harness (set `DOMAINS` and `CLIENT_DOMAIN` to exercise multi-domain).
 - `scripts/bench/run_rust_rust_10mb.sh`: Rust<->Rust throughput benchmark (set `RESOLVER_MODE=mixed` for mixed resolver runs).

--- a/scripts/build_picoquic.sh
+++ b/scripts/build_picoquic.sh
@@ -12,6 +12,17 @@ if [[ ! -d "${PICOQUIC_DIR}" ]]; then
   exit 1
 fi
 
+IS_WINDOWS=0
+case "${OSTYPE:-}" in
+  msys*|cygwin*) IS_WINDOWS=1 ;;
+esac
+if [[ "$IS_WINDOWS" == "0" ]]; then
+  UNAME_S=$(uname -s 2>/dev/null || echo "")
+  case "$UNAME_S" in
+    MSYS*|MINGW*|CYGWIN*) IS_WINDOWS=1 ;;
+  esac
+fi
+
 CMAKE_ARGS=(
   "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
   "-DPICOQUIC_FETCH_PTLS=${FETCH_PTLS}"
@@ -20,6 +31,22 @@ CMAKE_ARGS=(
 )
 
 BUILD_TARGET=()
+
+if [[ "$IS_WINDOWS" == "1" ]]; then
+  CMAKE_ARGS+=("-DBUILD_TESTING=OFF")
+  CMAKE_ARGS+=("-Dpicoquic_BUILD_TESTS=OFF")
+
+  if [[ -d "/c/Program Files/Microsoft Visual Studio/2022" ]] || [[ -d "C:/Program Files/Microsoft Visual Studio/2022" ]]; then
+    CMAKE_ARGS+=("-G" "Visual Studio 17 2022" "-A" "x64")
+    echo "Using Visual Studio 2022 generator" >&2
+  elif [[ -d "/c/Program Files (x86)/Microsoft Visual Studio/2019" ]] || [[ -d "C:/Program Files (x86)/Microsoft Visual Studio/2019" ]]; then
+    CMAKE_ARGS+=("-G" "Visual Studio 16 2019" "-A" "x64")
+    echo "Using Visual Studio 2019 generator" >&2
+  fi
+
+  BUILD_TARGET=(--target picoquic-core picotls-core picotls-fusion picotls-minicrypto picotls-openssl)
+fi
+
 if [[ -n "${CARGO_FEATURE_PICOQUIC_MINIMAL_BUILD:-}" ]]; then
   case "${CARGO_FEATURE_PICOQUIC_MINIMAL_BUILD,,}" in
     1|true|yes|on)
@@ -82,8 +109,37 @@ if [[ -n "${OPENSSL_USE_STATIC_LIBS:-}" ]]; then
 fi
 
 cmake -S "${PICOQUIC_DIR}" -B "${BUILD_DIR}" "${CMAKE_ARGS[@]}"
-if [[ ${#BUILD_TARGET[@]} -gt 0 ]]; then
-  cmake --build "${BUILD_DIR}" "${BUILD_TARGET[@]}"
+
+if [[ "$IS_WINDOWS" == "1" ]]; then
+  if [[ ${#BUILD_TARGET[@]} -gt 0 ]]; then
+    cmake --build "${BUILD_DIR}" --config "${BUILD_TYPE}" "${BUILD_TARGET[@]}"
+  else
+    cmake --build "${BUILD_DIR}" --config "${BUILD_TYPE}"
+  fi
 else
-  cmake --build "${BUILD_DIR}"
+  if [[ ${#BUILD_TARGET[@]} -gt 0 ]]; then
+    cmake --build "${BUILD_DIR}" "${BUILD_TARGET[@]}"
+  else
+    cmake --build "${BUILD_DIR}"
+  fi
+fi
+
+if [[ "$IS_WINDOWS" == "1" ]]; then
+  for BUILD_CONFIG in Debug Release; do
+    RELEASE_DIR="${BUILD_DIR}/${BUILD_CONFIG}"
+    PTLS_RELEASE="${BUILD_DIR}/_deps/picotls-build/${BUILD_CONFIG}"
+
+    [[ -d "$RELEASE_DIR" ]] || continue
+
+    for lib in picoquic-core picotls-core picotls-fusion picotls-minicrypto picotls-openssl; do
+      src_dir="$RELEASE_DIR"
+      [[ "$lib" != "picoquic-core" ]] && src_dir="$PTLS_RELEASE"
+
+      if [[ -f "$src_dir/${lib}.lib" ]]; then
+        cp "$src_dir/${lib}.lib" "${BUILD_DIR}/lib${lib}.a" 2>/dev/null || true
+        underscored=$(echo "$lib" | tr '-' '_')
+        cp "$src_dir/${lib}.lib" "${BUILD_DIR}/lib${underscored}.a" 2>/dev/null || true
+      fi
+    done
+  done
 fi

--- a/scripts/build_picoquic.sh
+++ b/scripts/build_picoquic.sh
@@ -23,6 +23,11 @@ if [[ "$IS_WINDOWS" == "0" ]]; then
   esac
 fi
 
+if [[ "$IS_WINDOWS" == "1" ]]; then
+  echo "Windows builds are supported via scripts/build_picoquic_windows.ps1. This CMake helper is non-Windows only." >&2
+  exit 1
+fi
+
 CMAKE_ARGS=(
   "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
   "-DPICOQUIC_FETCH_PTLS=${FETCH_PTLS}"
@@ -31,21 +36,6 @@ CMAKE_ARGS=(
 )
 
 BUILD_TARGET=()
-
-if [[ "$IS_WINDOWS" == "1" ]]; then
-  CMAKE_ARGS+=("-DBUILD_TESTING=OFF")
-  CMAKE_ARGS+=("-Dpicoquic_BUILD_TESTS=OFF")
-
-  if [[ -d "/c/Program Files/Microsoft Visual Studio/2022" ]] || [[ -d "C:/Program Files/Microsoft Visual Studio/2022" ]]; then
-    CMAKE_ARGS+=("-G" "Visual Studio 17 2022" "-A" "x64")
-    echo "Using Visual Studio 2022 generator" >&2
-  elif [[ -d "/c/Program Files (x86)/Microsoft Visual Studio/2019" ]] || [[ -d "C:/Program Files (x86)/Microsoft Visual Studio/2019" ]]; then
-    CMAKE_ARGS+=("-G" "Visual Studio 16 2019" "-A" "x64")
-    echo "Using Visual Studio 2019 generator" >&2
-  fi
-
-  BUILD_TARGET=(--target picoquic-core picotls-core picotls-fusion picotls-minicrypto picotls-openssl)
-fi
 
 if [[ -n "${CARGO_FEATURE_PICOQUIC_MINIMAL_BUILD:-}" ]]; then
   case "${CARGO_FEATURE_PICOQUIC_MINIMAL_BUILD,,}" in
@@ -110,36 +100,8 @@ fi
 
 cmake -S "${PICOQUIC_DIR}" -B "${BUILD_DIR}" "${CMAKE_ARGS[@]}"
 
-if [[ "$IS_WINDOWS" == "1" ]]; then
-  if [[ ${#BUILD_TARGET[@]} -gt 0 ]]; then
-    cmake --build "${BUILD_DIR}" --config "${BUILD_TYPE}" "${BUILD_TARGET[@]}"
-  else
-    cmake --build "${BUILD_DIR}" --config "${BUILD_TYPE}"
-  fi
+if [[ ${#BUILD_TARGET[@]} -gt 0 ]]; then
+  cmake --build "${BUILD_DIR}" "${BUILD_TARGET[@]}"
 else
-  if [[ ${#BUILD_TARGET[@]} -gt 0 ]]; then
-    cmake --build "${BUILD_DIR}" "${BUILD_TARGET[@]}"
-  else
-    cmake --build "${BUILD_DIR}"
-  fi
-fi
-
-if [[ "$IS_WINDOWS" == "1" ]]; then
-  for BUILD_CONFIG in Debug Release; do
-    RELEASE_DIR="${BUILD_DIR}/${BUILD_CONFIG}"
-    PTLS_RELEASE="${BUILD_DIR}/_deps/picotls-build/${BUILD_CONFIG}"
-
-    [[ -d "$RELEASE_DIR" ]] || continue
-
-    for lib in picoquic-core picotls-core picotls-fusion picotls-minicrypto picotls-openssl; do
-      src_dir="$RELEASE_DIR"
-      [[ "$lib" != "picoquic-core" ]] && src_dir="$PTLS_RELEASE"
-
-      if [[ -f "$src_dir/${lib}.lib" ]]; then
-        cp "$src_dir/${lib}.lib" "${BUILD_DIR}/lib${lib}.a" 2>/dev/null || true
-        underscored=$(echo "$lib" | tr '-' '_')
-        cp "$src_dir/${lib}.lib" "${BUILD_DIR}/lib${underscored}.a" 2>/dev/null || true
-      fi
-    done
-  done
+  cmake --build "${BUILD_DIR}"
 fi

--- a/scripts/build_picoquic.sh
+++ b/scripts/build_picoquic.sh
@@ -12,22 +12,6 @@ if [[ ! -d "${PICOQUIC_DIR}" ]]; then
   exit 1
 fi
 
-IS_WINDOWS=0
-case "${OSTYPE:-}" in
-  msys*|cygwin*) IS_WINDOWS=1 ;;
-esac
-if [[ "$IS_WINDOWS" == "0" ]]; then
-  UNAME_S=$(uname -s 2>/dev/null || echo "")
-  case "$UNAME_S" in
-    MSYS*|MINGW*|CYGWIN*) IS_WINDOWS=1 ;;
-  esac
-fi
-
-if [[ "$IS_WINDOWS" == "1" ]]; then
-  echo "Windows builds are supported via scripts/build_picoquic_windows.ps1. This CMake helper is non-Windows only." >&2
-  exit 1
-fi
-
 CMAKE_ARGS=(
   "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
   "-DPICOQUIC_FETCH_PTLS=${FETCH_PTLS}"

--- a/scripts/build_picoquic_windows.ps1
+++ b/scripts/build_picoquic_windows.ps1
@@ -4,6 +4,7 @@ param(
     [string]$PicoquicDir = "",
     [string]$PicotlsDir = "",
     [string]$StageDir = "",
+    [string]$OpenSslStageDir = "",
     [string]$PicotlsCommit = "5a4461d8a3948d9d26bf861e7d90cb80d8093515",
     [string]$Configuration = "Release",
     [string]$Platform = "x64",
@@ -105,6 +106,116 @@ function Get-WindowsSdkVersion {
     return $windowsSdk
 }
 
+function Export-EnvValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    Set-Item -Path "Env:$Name" -Value $Value
+    if ($env:GITHUB_ENV) {
+        "$Name=$Value" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+    }
+}
+
+function Get-OpenSslLayout {
+    if (![string]::IsNullOrWhiteSpace($env:OPENSSL_LIB_DIR) -and
+        ![string]::IsNullOrWhiteSpace($env:OPENSSL_INCLUDE_DIR)) {
+        if (!(Test-Path $env:OPENSSL_LIB_DIR)) {
+            throw "OPENSSL_LIB_DIR does not exist: $env:OPENSSL_LIB_DIR"
+        }
+        if (!(Test-Path $env:OPENSSL_INCLUDE_DIR)) {
+            throw "OPENSSL_INCLUDE_DIR does not exist: $env:OPENSSL_INCLUDE_DIR"
+        }
+        return @{
+            Root = if ($env:OPENSSL_ROOT_DIR) { $env:OPENSSL_ROOT_DIR } else { Split-Path -Parent $env:OPENSSL_INCLUDE_DIR }
+            IncludeDir = $env:OPENSSL_INCLUDE_DIR
+            LibDir = $env:OPENSSL_LIB_DIR
+        }
+    }
+
+    $opensslPaths = @()
+    foreach ($path in @($env:OPENSSL_ROOT_DIR, $env:OPENSSL_DIR, $env:OPENSSL64DIR)) {
+        if (![string]::IsNullOrWhiteSpace($path)) {
+            $opensslPaths += $path
+        }
+    }
+    $opensslPaths += @(
+        "C:\Program Files\OpenSSL",
+        "C:\Program Files\OpenSSL-Win64",
+        "C:\OpenSSL-Win64",
+        "C:\OpenSSL"
+    )
+
+    foreach ($path in $opensslPaths) {
+        if (!(Test-Path $path)) {
+            continue
+        }
+        $includeDir = Join-Path $path "include"
+        if (!(Test-Path $includeDir)) {
+            continue
+        }
+        $libDir = Get-ChildItem -Path (Join-Path $path "lib") -Filter "libcrypto*.lib" -Recurse -ErrorAction SilentlyContinue |
+            Select-Object -First 1 |
+            ForEach-Object { $_.DirectoryName }
+        if ($libDir) {
+            return @{
+                Root = $path
+                IncludeDir = $includeDir
+                LibDir = $libDir
+            }
+        }
+    }
+
+    throw "Could not locate an OpenSSL install with include files and libcrypto*.lib."
+}
+
+function Initialize-OpenSslStage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Layout,
+        [Parameter(Mandatory = $true)]
+        [string]$StageDir
+    )
+
+    $sourceIncludeDir = $Layout["IncludeDir"]
+    $sourceLibDir = $Layout["LibDir"]
+    $stageIncludeDir = Join-Path $StageDir "include"
+    $stageLibDir = Join-Path $StageDir "lib"
+
+    New-Item -ItemType Directory -Force -Path $stageIncludeDir, $stageLibDir | Out-Null
+    Copy-Item -Recurse -Force (Join-Path $sourceIncludeDir "*") $stageIncludeDir
+
+    $libcrypto = Get-ChildItem -Path $sourceLibDir -Filter "libcrypto*.lib" |
+        Sort-Object Name |
+        Select-Object -First 1
+    if (!$libcrypto) {
+        throw "Could not find libcrypto import library under $sourceLibDir"
+    }
+    $libssl = Get-ChildItem -Path $sourceLibDir -Filter "libssl*.lib" |
+        Sort-Object Name |
+        Select-Object -First 1
+    if (!$libssl) {
+        throw "Could not find libssl import library under $sourceLibDir"
+    }
+
+    Copy-Item -Force $libcrypto.FullName $stageLibDir
+    Copy-Item -Force $libssl.FullName $stageLibDir
+    Copy-Item -Force $libcrypto.FullName (Join-Path $stageLibDir "libcrypto.lib")
+    Copy-Item -Force $libssl.FullName (Join-Path $stageLibDir "libssl.lib")
+    Copy-Item -Force $libcrypto.FullName (Join-Path $StageDir "libcrypto.lib")
+
+    Export-EnvValue -Name "OPENSSL_DIR" -Value $StageDir
+    Export-EnvValue -Name "OPENSSL_ROOT_DIR" -Value $StageDir
+    Export-EnvValue -Name "OPENSSL64DIR" -Value $StageDir
+    Export-EnvValue -Name "OPENSSL_INCLUDE_DIR" -Value $stageIncludeDir
+    Export-EnvValue -Name "OPENSSL_LIB_DIR" -Value $stageLibDir
+    $sourceRoot = $Layout["Root"]
+    Write-Host "OpenSSL staged in $StageDir from $sourceRoot"
+}
+
 if (!$IsWindows) {
     throw "scripts/build_picoquic_windows.ps1 must be run on a Windows host."
 }
@@ -130,24 +241,23 @@ if ([string]::IsNullOrWhiteSpace($StageDir)) {
     $StageDir = Join-Path $stageRoot "$Platform\$Configuration"
 }
 
-if (!(Test-Path $PicoquicDir)) {
-    throw "picoquic not found at $PicoquicDir. Run: git submodule update --init --recursive vendor/picoquic"
+if ([string]::IsNullOrWhiteSpace($OpenSslStageDir)) {
+    $stagePlatformDir = Split-Path -Parent $StageDir
+    $stageRootDir = Split-Path -Parent $stagePlatformDir
+    $OpenSslStageDir = Join-Path $stageRootDir "openssl"
 }
 
-if ([string]::IsNullOrWhiteSpace($env:OPENSSL_LIB_DIR)) {
-    throw "OPENSSL_LIB_DIR must be set for the Windows picoquic build."
-}
-if ([string]::IsNullOrWhiteSpace($env:OPENSSL64DIR)) {
-    throw "OPENSSL64DIR must be set for the Windows picoquic build."
-}
-if (!(Test-Path $env:OPENSSL64DIR)) {
-    throw "OPENSSL64DIR does not exist: $env:OPENSSL64DIR"
+if (!(Test-Path $PicoquicDir)) {
+    throw "picoquic not found at $PicoquicDir. Run: git submodule update --init --recursive vendor/picoquic"
 }
 
 $msbuild = Get-MSBuildPath
 if ([string]::IsNullOrWhiteSpace($WindowsSdk)) {
     $WindowsSdk = Get-WindowsSdkVersion
 }
+
+$opensslLayout = Get-OpenSslLayout
+Initialize-OpenSslStage -Layout $opensslLayout -StageDir $OpenSslStageDir
 
 if (!(Test-Path $PicotlsDir)) {
     New-Item -ItemType Directory -Force -Path (Split-Path -Parent $PicotlsDir) | Out-Null
@@ -156,14 +266,6 @@ if (!(Test-Path $PicotlsDir)) {
         throw "Failed to clone picotls into $PicotlsDir"
     }
 }
-
-$libcrypto = Get-ChildItem -Path $env:OPENSSL_LIB_DIR -Filter "libcrypto*.lib" |
-    Sort-Object Name |
-    Select-Object -First 1
-if (!$libcrypto) {
-    throw "Could not find libcrypto import library under $env:OPENSSL_LIB_DIR"
-}
-Copy-Item -Force $libcrypto.FullName (Join-Path $env:OPENSSL64DIR "libcrypto.lib")
 
 Invoke-Git -WorkingDir $PicotlsDir -Arguments @("fetch", "--depth", "1", "origin", $PicotlsCommit)
 Invoke-Git -WorkingDir $PicotlsDir -Arguments @("checkout", "-q", $PicotlsCommit)

--- a/scripts/build_picoquic_windows.ps1
+++ b/scripts/build_picoquic_windows.ps1
@@ -1,0 +1,269 @@
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+    [string]$PicoquicDir = "",
+    [string]$PicotlsDir = "",
+    [string]$StageDir = "",
+    [string]$PicotlsCommit = "5a4461d8a3948d9d26bf861e7d90cb80d8093515",
+    [string]$Configuration = "Release",
+    [string]$Platform = "x64",
+    [string]$PlatformToolset = "v143",
+    [string]$WindowsSdk = ""
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$WorkingDir,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    & git -C $WorkingDir @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "git failed in ${WorkingDir}: git $($Arguments -join ' ')"
+    }
+}
+
+function Invoke-MSBuildProject {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$MsBuild,
+        [Parameter(Mandatory = $true)]
+        [string]$Project,
+        [string]$Target = "",
+        [Parameter(Mandatory = $true)]
+        [string]$Configuration,
+        [Parameter(Mandatory = $true)]
+        [string]$Platform,
+        [Parameter(Mandatory = $true)]
+        [string]$PlatformToolset,
+        [Parameter(Mandatory = $true)]
+        [string]$WindowsSdk
+    )
+
+    $args = @(
+        "/p:Configuration=$Configuration",
+        "/p:Platform=$Platform",
+        "/p:PlatformToolset=$PlatformToolset",
+        "/p:WindowsTargetPlatformVersion=$WindowsSdk",
+        "/m"
+    )
+    if (![string]::IsNullOrWhiteSpace($Target)) {
+        $args += "/t:$Target"
+    }
+    $args += $Project
+    & $MsBuild @args
+    if ($LASTEXITCODE -ne 0) {
+        throw "MSBuild failed for $Project"
+    }
+}
+
+function Get-FirstExistingPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Candidates
+    )
+
+    foreach ($candidate in $Candidates) {
+        if (Test-Path $candidate) {
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+function Get-MSBuildPath {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (!(Test-Path $vswhere)) {
+        throw "Could not locate vswhere.exe"
+    }
+
+    $msbuild = & $vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe |
+        Select-Object -First 1
+    if (!$msbuild) {
+        throw "Could not locate MSBuild.exe"
+    }
+
+    return $msbuild
+}
+
+function Get-WindowsSdkVersion {
+    $sdkRoot = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\Include"
+    $windowsSdk = Get-ChildItem $sdkRoot -Directory |
+        Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+        Sort-Object { [version]$_.Name } -Descending |
+        Select-Object -First 1 -ExpandProperty Name
+    if (!$windowsSdk) {
+        throw "Could not locate an installed Windows SDK"
+    }
+
+    return $windowsSdk
+}
+
+if (!$IsWindows) {
+    throw "scripts/build_picoquic_windows.ps1 must be run on a Windows host."
+}
+
+if ([string]::IsNullOrWhiteSpace($PicoquicDir)) {
+    if ($env:PICOQUIC_DIR) {
+        $PicoquicDir = $env:PICOQUIC_DIR
+    } else {
+        $PicoquicDir = Join-Path $RepoRoot "vendor\picoquic"
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($PicotlsDir)) {
+    $PicotlsDir = Join-Path $RepoRoot "vendor\picotls"
+}
+
+if ([string]::IsNullOrWhiteSpace($StageDir)) {
+    $stageRoot = if ($env:PICOQUIC_BUILD_DIR) {
+        $env:PICOQUIC_BUILD_DIR
+    } else {
+        Join-Path $RepoRoot ".picoquic-build\windows"
+    }
+    $StageDir = Join-Path $stageRoot "$Platform\$Configuration"
+}
+
+if (!(Test-Path $PicoquicDir)) {
+    throw "picoquic not found at $PicoquicDir. Run: git submodule update --init --recursive vendor/picoquic"
+}
+
+if ([string]::IsNullOrWhiteSpace($env:OPENSSL_LIB_DIR)) {
+    throw "OPENSSL_LIB_DIR must be set for the Windows picoquic build."
+}
+if ([string]::IsNullOrWhiteSpace($env:OPENSSL64DIR)) {
+    throw "OPENSSL64DIR must be set for the Windows picoquic build."
+}
+if (!(Test-Path $env:OPENSSL64DIR)) {
+    throw "OPENSSL64DIR does not exist: $env:OPENSSL64DIR"
+}
+
+$msbuild = Get-MSBuildPath
+if ([string]::IsNullOrWhiteSpace($WindowsSdk)) {
+    $WindowsSdk = Get-WindowsSdkVersion
+}
+
+if (!(Test-Path $PicotlsDir)) {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $PicotlsDir) | Out-Null
+    & git clone https://github.com/h2o/picotls $PicotlsDir
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to clone picotls into $PicotlsDir"
+    }
+}
+
+$libcrypto = Get-ChildItem -Path $env:OPENSSL_LIB_DIR -Filter "libcrypto*.lib" |
+    Sort-Object Name |
+    Select-Object -First 1
+if (!$libcrypto) {
+    throw "Could not find libcrypto import library under $env:OPENSSL_LIB_DIR"
+}
+Copy-Item -Force $libcrypto.FullName (Join-Path $env:OPENSSL64DIR "libcrypto.lib")
+
+Invoke-Git -WorkingDir $PicotlsDir -Arguments @("fetch", "--depth", "1", "origin", $PicotlsCommit)
+Invoke-Git -WorkingDir $PicotlsDir -Arguments @("checkout", "-q", $PicotlsCommit)
+Invoke-Git -WorkingDir $PicotlsDir -Arguments @("submodule", "update", "--init", "--recursive")
+
+$picotlsProjects = @(
+    "picotlsvs\picotls-core\picotls-core.vcxproj",
+    "picotlsvs\picotls-openssl\picotls-openssl.vcxproj",
+    "picotlsvs\picotls-minicrypto\picotls-minicrypto.vcxproj",
+    "picotlsvs\picotls-fusion\picotls-fusion.vcxproj",
+    "picotlsvs\cifra\cifra.vcxproj",
+    "picotlsvs\microecc\microecc.vcxproj"
+)
+foreach ($project in $picotlsProjects) {
+    Invoke-MSBuildProject `
+        -MsBuild $msbuild `
+        -Project (Join-Path $PicotlsDir $project) `
+        -Configuration $Configuration `
+        -Platform $Platform `
+        -PlatformToolset $PlatformToolset `
+        -WindowsSdk $WindowsSdk
+}
+
+Invoke-MSBuildProject `
+    -MsBuild $msbuild `
+    -Project (Join-Path $PicoquicDir "picoquic.sln") `
+    -Target "picoquic" `
+    -Configuration $Configuration `
+    -Platform $Platform `
+    -PlatformToolset $PlatformToolset `
+    -WindowsSdk $WindowsSdk
+
+New-Item -ItemType Directory -Force -Path $StageDir | Out-Null
+$requiredLibs = @(
+    @{
+        Name = "picoquic.lib"
+        Candidates = @(
+            (Join-Path $PicoquicDir "$Platform\$Configuration\picoquic.lib"),
+            (Join-Path $PicoquicDir "picoquic\$Platform\$Configuration\picoquic.lib")
+        )
+    },
+    @{
+        Name = "picotls-core.lib"
+        Candidates = @(
+            (Join-Path $PicotlsDir "picotlsvs\picotls-core\$Platform\$Configuration\picotls-core.lib"),
+            (Join-Path $PicotlsDir "picotlsvs\$Platform\$Configuration\picotls-core.lib")
+        )
+    },
+    @{
+        Name = "picotls-openssl.lib"
+        Candidates = @(
+            (Join-Path $PicotlsDir "picotlsvs\picotls-openssl\$Platform\$Configuration\picotls-openssl.lib"),
+            (Join-Path $PicotlsDir "picotlsvs\$Platform\$Configuration\picotls-openssl.lib")
+        )
+    },
+    @{
+        Name = "picotls-minicrypto.lib"
+        Candidates = @(
+            (Join-Path $PicotlsDir "picotlsvs\picotls-minicrypto\$Platform\$Configuration\picotls-minicrypto.lib"),
+            (Join-Path $PicotlsDir "picotlsvs\$Platform\$Configuration\picotls-minicrypto.lib")
+        )
+    },
+    @{
+        Name = "picotls-fusion.lib"
+        Candidates = @(
+            (Join-Path $PicotlsDir "picotlsvs\picotls-fusion\$Platform\$Configuration\picotls-fusion.lib"),
+            (Join-Path $PicotlsDir "picotlsvs\$Platform\$Configuration\picotls-fusion.lib")
+        )
+    },
+    @{
+        Name = "cifra.lib"
+        Candidates = @(
+            (Join-Path $PicotlsDir "picotlsvs\cifra\$Platform\$Configuration\cifra.lib"),
+            (Join-Path $PicotlsDir "picotlsvs\$Platform\$Configuration\cifra.lib")
+        )
+    },
+    @{
+        Name = "microecc.lib"
+        Candidates = @(
+            (Join-Path $PicotlsDir "picotlsvs\microecc\$Platform\$Configuration\microecc.lib"),
+            (Join-Path $PicotlsDir "picotlsvs\$Platform\$Configuration\microecc.lib")
+        )
+    }
+)
+
+foreach ($lib in $requiredLibs) {
+    $libPath = Get-FirstExistingPath -Candidates $lib.Candidates
+    if (!$libPath) {
+        throw "Missing expected Windows library $($lib.Name). Checked: $($lib.Candidates -join ', ')"
+    }
+    Copy-Item -Force $libPath $StageDir
+}
+
+Get-ChildItem -Path $StageDir -Filter "*.lib" |
+    Sort-Object Name |
+    Select-Object Name, FullName |
+    Format-Table -AutoSize |
+    Out-String |
+    Write-Host
+
+Write-Host "Staged Windows picoquic artifacts in $StageDir"
+Write-Host "picoquic headers: $(Join-Path $PicoquicDir 'picoquic')"
+Write-Host "picotls headers: $(Join-Path $PicotlsDir 'include')"

--- a/scripts/build_picoquic_windows.ps1
+++ b/scripts/build_picoquic_windows.ps1
@@ -78,6 +78,46 @@ function Get-FirstExistingPath {
     return $null
 }
 
+function Get-OpenSslStaticLibraryPair {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$LibDirs
+    )
+
+    $pairs = @(
+        @{
+            Ssl = "libssl64MD.lib"
+            Crypto = "libcrypto64MD.lib"
+        },
+        @{
+            Ssl = "libssl_static.lib"
+            Crypto = "libcrypto_static.lib"
+        }
+    )
+
+    foreach ($libDir in $LibDirs) {
+        if (!(Test-Path $libDir)) {
+            continue
+        }
+
+        foreach ($pair in $pairs) {
+            $ssl = Join-Path $libDir $pair["Ssl"]
+            $crypto = Join-Path $libDir $pair["Crypto"]
+            if ((Test-Path $ssl) -and (Test-Path $crypto)) {
+                return @{
+                    LibDir = $libDir
+                    Ssl = $ssl
+                    Crypto = $crypto
+                    SslName = [System.IO.Path]::GetFileNameWithoutExtension($ssl)
+                    CryptoName = [System.IO.Path]::GetFileNameWithoutExtension($crypto)
+                }
+            }
+        }
+    }
+
+    return $null
+}
+
 function Get-MSBuildPath {
     $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
     if (!(Test-Path $vswhere)) {
@@ -129,10 +169,22 @@ function Get-OpenSslLayout {
         if (!(Test-Path $env:OPENSSL_INCLUDE_DIR)) {
             throw "OPENSSL_INCLUDE_DIR does not exist: $env:OPENSSL_INCLUDE_DIR"
         }
+        $staticPair = Get-OpenSslStaticLibraryPair -LibDirs @(
+            $env:OPENSSL_LIB_DIR,
+            (Join-Path $env:OPENSSL_LIB_DIR "VC"),
+            (Join-Path $env:OPENSSL_LIB_DIR "VC\x64\MD")
+        )
+        if (!$staticPair) {
+            throw "Could not find static OpenSSL libraries under OPENSSL_LIB_DIR: $env:OPENSSL_LIB_DIR"
+        }
         return @{
             Root = if ($env:OPENSSL_ROOT_DIR) { $env:OPENSSL_ROOT_DIR } else { Split-Path -Parent $env:OPENSSL_INCLUDE_DIR }
             IncludeDir = $env:OPENSSL_INCLUDE_DIR
-            LibDir = $env:OPENSSL_LIB_DIR
+            LibDir = $staticPair["LibDir"]
+            Ssl = $staticPair["Ssl"]
+            Crypto = $staticPair["Crypto"]
+            SslName = $staticPair["SslName"]
+            CryptoName = $staticPair["CryptoName"]
         }
     }
 
@@ -157,19 +209,26 @@ function Get-OpenSslLayout {
         if (!(Test-Path $includeDir)) {
             continue
         }
-        $libDir = Get-ChildItem -Path (Join-Path $path "lib") -Filter "libcrypto*.lib" -Recurse -ErrorAction SilentlyContinue |
-            Select-Object -First 1 |
-            ForEach-Object { $_.DirectoryName }
-        if ($libDir) {
+        $libRoot = Join-Path $path "lib"
+        $staticPair = Get-OpenSslStaticLibraryPair -LibDirs @(
+            (Join-Path $libRoot "VC"),
+            (Join-Path $libRoot "VC\x64\MD"),
+            $libRoot
+        )
+        if ($staticPair) {
             return @{
                 Root = $path
                 IncludeDir = $includeDir
-                LibDir = $libDir
+                LibDir = $staticPair["LibDir"]
+                Ssl = $staticPair["Ssl"]
+                Crypto = $staticPair["Crypto"]
+                SslName = $staticPair["SslName"]
+                CryptoName = $staticPair["CryptoName"]
             }
         }
     }
 
-    throw "Could not locate an OpenSSL install with include files and libcrypto*.lib."
+    throw "Could not locate an OpenSSL install with include files and static MSVC libraries."
 }
 
 function Initialize-OpenSslStage {
@@ -181,39 +240,32 @@ function Initialize-OpenSslStage {
     )
 
     $sourceIncludeDir = $Layout["IncludeDir"]
-    $sourceLibDir = $Layout["LibDir"]
+    $sourceSsl = $Layout["Ssl"]
+    $sourceCrypto = $Layout["Crypto"]
+    $sslName = $Layout["SslName"]
+    $cryptoName = $Layout["CryptoName"]
     $stageIncludeDir = Join-Path $StageDir "include"
     $stageLibDir = Join-Path $StageDir "lib"
 
     New-Item -ItemType Directory -Force -Path $stageIncludeDir, $stageLibDir | Out-Null
     Copy-Item -Recurse -Force (Join-Path $sourceIncludeDir "*") $stageIncludeDir
 
-    $libcrypto = Get-ChildItem -Path $sourceLibDir -Filter "libcrypto*.lib" |
-        Sort-Object Name |
-        Select-Object -First 1
-    if (!$libcrypto) {
-        throw "Could not find libcrypto import library under $sourceLibDir"
-    }
-    $libssl = Get-ChildItem -Path $sourceLibDir -Filter "libssl*.lib" |
-        Sort-Object Name |
-        Select-Object -First 1
-    if (!$libssl) {
-        throw "Could not find libssl import library under $sourceLibDir"
-    }
-
-    Copy-Item -Force $libcrypto.FullName $stageLibDir
-    Copy-Item -Force $libssl.FullName $stageLibDir
-    Copy-Item -Force $libcrypto.FullName (Join-Path $stageLibDir "libcrypto.lib")
-    Copy-Item -Force $libssl.FullName (Join-Path $stageLibDir "libssl.lib")
-    Copy-Item -Force $libcrypto.FullName (Join-Path $StageDir "libcrypto.lib")
+    Copy-Item -Force $sourceCrypto $stageLibDir
+    Copy-Item -Force $sourceSsl $stageLibDir
 
     Export-EnvValue -Name "OPENSSL_DIR" -Value $StageDir
     Export-EnvValue -Name "OPENSSL_ROOT_DIR" -Value $StageDir
     Export-EnvValue -Name "OPENSSL64DIR" -Value $StageDir
     Export-EnvValue -Name "OPENSSL_INCLUDE_DIR" -Value $stageIncludeDir
     Export-EnvValue -Name "OPENSSL_LIB_DIR" -Value $stageLibDir
+    Export-EnvValue -Name "OPENSSL_SSL_LIBRARY" -Value (Join-Path $stageLibDir (Split-Path -Leaf $sourceSsl))
+    Export-EnvValue -Name "OPENSSL_CRYPTO_LIBRARY" -Value (Join-Path $stageLibDir (Split-Path -Leaf $sourceCrypto))
+    Export-EnvValue -Name "OPENSSL_LIBS" -Value "${sslName}:${cryptoName}"
+    Export-EnvValue -Name "OPENSSL_STATIC" -Value "1"
+    Export-EnvValue -Name "OPENSSL_USE_STATIC_LIBS" -Value "TRUE"
     $sourceRoot = $Layout["Root"]
-    Write-Host "OpenSSL staged in $StageDir from $sourceRoot"
+    Write-Host "Static OpenSSL staged in $StageDir from $sourceRoot"
+    Write-Host "OpenSSL libraries: ${sslName}, ${cryptoName}"
 }
 
 if (!$IsWindows) {

--- a/scripts/build_picoquic_windows.ps1
+++ b/scripts/build_picoquic_windows.ps1
@@ -46,7 +46,7 @@ function Invoke-MSBuildProject {
         [string]$WindowsSdk
     )
 
-    $args = @(
+    $msbuildArgs = @(
         "/p:Configuration=$Configuration",
         "/p:Platform=$Platform",
         "/p:PlatformToolset=$PlatformToolset",
@@ -54,10 +54,10 @@ function Invoke-MSBuildProject {
         "/m"
     )
     if (![string]::IsNullOrWhiteSpace($Target)) {
-        $args += "/t:$Target"
+        $msbuildArgs += "/t:$Target"
     }
-    $args += $Project
-    & $MsBuild @args
+    $msbuildArgs += $Project
+    & $MsBuild @msbuildArgs
     if ($LASTEXITCODE -ne 0) {
         throw "MSBuild failed for $Project"
     }

--- a/scripts/verify_windows_artifact_deps.ps1
+++ b/scripts/verify_windows_artifact_deps.ps1
@@ -1,0 +1,59 @@
+[CmdletBinding()]
+param(
+    [string]$DistDir = "dist"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-DumpbinPath {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (!(Test-Path $vswhere)) {
+        throw "Could not locate vswhere.exe"
+    }
+
+    $installPath = & $vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    if (!$installPath) {
+        throw "Could not locate a Visual Studio installation with VC tools"
+    }
+
+    $msvcRoot = Join-Path $installPath "VC\Tools\MSVC"
+    $dumpbin = Get-ChildItem -Path $msvcRoot -Filter "dumpbin.exe" -Recurse |
+        Where-Object {
+            $_.FullName -like "*\bin\Hostx64\x64\dumpbin.exe" -or
+            $_.FullName -like "*\bin\HostX64\x64\dumpbin.exe" -or
+            $_.FullName -like "*\bin\Hostx86\x64\dumpbin.exe" -or
+            $_.FullName -like "*\bin\HostX86\x64\dumpbin.exe"
+        } |
+        Sort-Object FullName -Descending |
+        Select-Object -First 1
+    if (!$dumpbin) {
+        throw "Could not locate dumpbin.exe under $msvcRoot"
+    }
+
+    return $dumpbin.FullName
+}
+
+if (!(Test-Path $DistDir)) {
+    throw "Distribution directory does not exist: $DistDir"
+}
+
+$executables = Get-ChildItem -Path $DistDir -Filter "*.exe"
+if (!$executables) {
+    throw "No Windows executables found under $DistDir"
+}
+
+$dumpbin = Get-DumpbinPath
+$failed = $false
+foreach ($exe in $executables) {
+    Write-Host "Checking dependencies for $($exe.FullName)"
+    $deps = & $dumpbin /dependents $exe.FullName
+    $deps | Out-String | Write-Host
+    if ($deps -match '(?i)\blib(ssl|crypto)(-[^\s]+)?\.dll\b') {
+        $failed = $true
+    }
+}
+
+if ($failed) {
+    throw "Windows artifacts depend on OpenSSL DLLs; expected static OpenSSL linkage."
+}

--- a/scripts/verify_windows_artifact_deps.ps1
+++ b/scripts/verify_windows_artifact_deps.ps1
@@ -44,16 +44,42 @@ if (!$executables) {
 }
 
 $dumpbin = Get-DumpbinPath
+$allowedDependencyPatterns = @(
+    '^(?i:advapi32|bcrypt|bcryptprimitives|crypt32|kernel32|ntdll|user32|vcruntime140|vcruntime140_1|ws2_32)\.dll$',
+    '^(?i:ucrtbase)\.dll$',
+    '^(?i:api-ms-win-(core|crt)-[a-z0-9-]+)\.dll$'
+)
 $failed = $false
 foreach ($exe in $executables) {
     Write-Host "Checking dependencies for $($exe.FullName)"
     $deps = & $dumpbin /dependents $exe.FullName
     $deps | Out-String | Write-Host
-    if ($deps -match '(?i)\blib(ssl|crypto)(-[^\s]+)?\.dll\b') {
+    $dlls = $deps |
+        ForEach-Object {
+            if ($_ -match '^\s*([A-Za-z0-9_.-]+\.dll)\s*$') {
+                $Matches[1]
+            }
+        } |
+        Sort-Object -Unique
+    $unexpectedDlls = @()
+    foreach ($dll in $dlls) {
+        $isAllowed = $false
+        foreach ($pattern in $allowedDependencyPatterns) {
+            if ($dll -match $pattern) {
+                $isAllowed = $true
+                break
+            }
+        }
+        if (!$isAllowed) {
+            $unexpectedDlls += $dll
+        }
+    }
+    if ($unexpectedDlls) {
         $failed = $true
+        Write-Host "Unexpected non-platform DLL dependencies: $($unexpectedDlls -join ', ')"
     }
 }
 
 if ($failed) {
-    throw "Windows artifacts depend on OpenSSL DLLs; expected static OpenSSL linkage."
+    throw "Windows artifacts depend on non-platform DLLs; expected standalone artifacts with only Windows and VC runtime dependencies."
 }

--- a/scripts/verify_windows_artifact_deps.ps1
+++ b/scripts/verify_windows_artifact_deps.ps1
@@ -45,7 +45,7 @@ if (!$executables) {
 
 $dumpbin = Get-DumpbinPath
 $allowedDependencyPatterns = @(
-    '^(?i:advapi32|bcrypt|bcryptprimitives|crypt32|kernel32|ntdll|user32|vcruntime140|vcruntime140_1|ws2_32)\.dll$',
+    '^(?i:advapi32|bcrypt|bcryptprimitives|crypt32|gdi32|kernel32|ntdll|user32|vcruntime140|vcruntime140_1|ws2_32)\.dll$',
     '^(?i:ucrtbase)\.dll$',
     '^(?i:api-ms-win-(core|crt)-[a-z0-9-]+)\.dll$'
 )


### PR DESCRIPTION
Adds Windows support with socket type compatibility, OpenSSL linking fixes, and IPv6 fallback for UDP socket binding.

**Changes:**
- Add `winapi` dependency for Windows socket types
- Fix OpenSSL library linking on Windows (`libssl`/`libcrypto` instead of `ssl`/`crypto`)
- Replace `pthread` with `ws2_32` on Windows
- Implement Windows-compatible `sockaddr_storage` using `winapi`
- Add Windows versions of `socket_addr_to_storage` and `sockaddr_storage_to_socket_addr`
- Update all server/client code to use platform-agnostic `SockaddrStorage` type
- Add IPv6→IPv4 fallback for UDP socket binding (common on Windows)


I test and build the changes in https://github.com/AliRezaBeigy/slipstream-rust-deploy