### PR TITLE
Handle mark_active_stream failures and add pending-send invariant logging

### DIFF
--- a/crates/slipstream-server/src/streams.rs
+++ b/crates/slipstream-server/src/streams.rs
@@ -1206,13 +1206,14 @@ mod tests {
         };
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
         let send_pending = Arc::new(AtomicBool::new(true));
+        let send_pending_handle = Arc::clone(&send_pending);
 
         state.streams.insert(
             key,
             ServerStream {
                 write_tx: None,
                 data_rx: None,
-                send_pending: Some(send_pending),
+                send_pending: Some(send_pending_handle),
                 send_stash: None,
                 shutdown_tx,
                 tx_bytes: 0,
@@ -1238,6 +1239,11 @@ mod tests {
         assert!(
             !state.streams.contains_key(&key),
             "stream state should be removed when mark_active_stream fails"
+        );
+        assert_eq!(
+            Arc::strong_count(&send_pending),
+            1,
+            "send_pending should be dropped when the stream is removed"
         );
     }
 }


### PR DESCRIPTION
- Adds invariant reporting when a zero-length send callback arrives with pending flag but no queued data, to catch stuck pending sends in crates/slipstream-server/src/streams.rs.
- Hardens mark_active_stream failure handling by shutting down the stream, logging detailed counters, and aborting the bidi stream (when not forced by tests).
- Adds a test to ensure forced mark_active_stream failure removes stream state and doesn’t leave send_pending stuck.

