### PR TITLE
Upgrade rust-openssl to 0.10.78

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",

--- a/crates/slipstream-client/Cargo.toml
+++ b/crates/slipstream-client/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../../README.md"
 [dependencies]
 clap = { workspace = true }
 libc = "0.2"
-openssl = "0.10"
+openssl = "0.10.78"
 socket2 = "0.6"
 slipstream-core = { path = "../slipstream-core" }
 slipstream-dns = { path = "../slipstream-dns" }

--- a/crates/slipstream-ffi/Cargo.toml
+++ b/crates/slipstream-ffi/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../../README.md"
 
 [dependencies]
 libc = "0.2"
-openssl-sys = { version = "0.9", optional = true, features = ["vendored"] }
+openssl-sys = { version = "0.9.114", optional = true, features = ["vendored"] }
 slipstream-core = { path = "../slipstream-core" }
 
 [features]

--- a/crates/slipstream-server/Cargo.toml
+++ b/crates/slipstream-server/Cargo.toml
@@ -13,7 +13,7 @@ slipstream-core = { path = "../slipstream-core" }
 slipstream-dns = { path = "../slipstream-dns" }
 slipstream-ffi = { path = "../slipstream-ffi" }
 libc = "0.2"
-openssl = "0.10"
+openssl = "0.10.78"
 socket2 = "0.6"
 tokio = { version = "1.37", features = ["io-util", "macros", "net", "rt", "sync", "time"] }
 time = { workspace = true }


### PR DESCRIPTION
Upgrade the Rust openssl crate to 0.10.78 and align the optional openssl-sys dependency with 0.9.114.

This picks up the rust-openssl security fixes released in openssl-v0.10.78, including fixes for CVE-2026-41676, CVE-2026-41677, CVE-2026-41678, CVE-2026-41681, and CVE-2026-41898.

Security references:
- https://github.com/rust-openssl/rust-openssl/releases/tag/openssl-v0.10.78
- https://seclists.org/oss-sec/2026/q2/214
- https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-pqf5-4pqq-29f5
- https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-xmgf-hq76-4vx2
- https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-8c75-8mhr-p7r9
- https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-ghm9-cr32-g9qj
- https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-hppc-g8h3-xhp3

I have ran `cargo test` and all tests pass.