### PR TITLE
Make EPIPE reset e2e test deterministic

### DIFF
--- a/crates/slipstream-server/tests/epipe_reset_e2e.rs
+++ b/crates/slipstream-server/tests/epipe_reset_e2e.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use socket2::SockRef;
 use support::{
     ensure_client_bin, log_snapshot, pick_tcp_port, pick_udp_port, server_bin_path,
     spawn_server_client_ready, spawn_single_target, test_cert_and_key, wait_for_any_log,
@@ -180,6 +181,7 @@ fn epipe_triggers_quic_reset() {
         );
     }
 
+    let _ = SockRef::from(&app).set_linger(Some(Duration::from_secs(0)));
     drop(app);
     let _ = app_closed_tx.send(());
 


### PR DESCRIPTION
Force the test app TCP socket to close with an RST before dropping it. A normal close can be observed as clean EOF, so the client does not always log the expected TCP read/write error even though the test is trying to exercise the reset path.

Using SO_LINGER=0 makes the injected failure deterministic and removes the intermittent cargo test failure in epipe_reset_e2e.

I've seen that tests are flaky multiple times locally and it happened once in https://github.com/Mygod/slipstream-rust/pull/85 as well. This PR fixes it.